### PR TITLE
Build as a purely standalone, static executable (fixes #7)

### DIFF
--- a/src/rosdiscover/CMakeLists.txt
+++ b/src/rosdiscover/CMakeLists.txt
@@ -2,7 +2,6 @@ add_executable(rosdiscover
   RosDiscover.cpp
 )
 
-# TODO compile these into a static executable with a static libc++
 llvm_map_components_to_libnames(ROSDISCOVER_LLVM_LIBS
   Demangle
 )


### PR DESCRIPTION
This compiles rosdiscover-cxx-extract using a static libc and stdlibc++. Although the result compiles and claims to be a working static executable, a warning message is produced (shown below), and so this may not actually work in practice.

```
/opt/llvm11/lib/libLLVMSupport.a(Path.cpp.o): In function `llvm::sys::fs::expandTildeExpr(llvm::SmallVectorImpl<char>&)':
Path.cpp:(.text._ZN4llvm3sys2fsL15expandTildeExprERNS_15SmallVectorImplIcEE+0x186): warning: Using 'getpwnam' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
```