### PR TITLE
Detect publish calls and rate sleeps

### DIFF
--- a/include/rosdiscover-clang/ApiCall/Calls.h
+++ b/include/rosdiscover-clang/ApiCall/Calls.h
@@ -16,6 +16,7 @@
 #include "Calls/HasParamCall.h"
 #include "Calls/Kind.h"
 #include "Calls/PublishCall.h"
+#include "Calls/RateSleepCall.h"
 #include "Calls/RosInitCall.h"
 #include "Calls/MessageFiltersSubscriberCall.h"
 #include "Calls/ServiceClientCall.h"

--- a/include/rosdiscover-clang/ApiCall/Calls.h
+++ b/include/rosdiscover-clang/ApiCall/Calls.h
@@ -15,6 +15,7 @@
 #include "Calls/GetParamWithDefaultCall.h"
 #include "Calls/HasParamCall.h"
 #include "Calls/Kind.h"
+#include "Calls/PublishCall.h"
 #include "Calls/RosInitCall.h"
 #include "Calls/MessageFiltersSubscriberCall.h"
 #include "Calls/ServiceClientCall.h"

--- a/include/rosdiscover-clang/ApiCall/Calls/Kind.h
+++ b/include/rosdiscover-clang/ApiCall/Calls/Kind.h
@@ -19,6 +19,7 @@ enum class RosApiCallKind {
   GetParamWithDefaultCall,
   HasParamCall,
   PublishCall,
+  RateSleepCall,
   RosInitCall,
   MessageFiltersSubscriberCall,
   ServiceClientCall,

--- a/include/rosdiscover-clang/ApiCall/Calls/Kind.h
+++ b/include/rosdiscover-clang/ApiCall/Calls/Kind.h
@@ -18,6 +18,7 @@ enum class RosApiCallKind {
   GetParamCall,
   GetParamWithDefaultCall,
   HasParamCall,
+  PublishCall,
   RosInitCall,
   MessageFiltersSubscriberCall,
   ServiceClientCall,

--- a/include/rosdiscover-clang/ApiCall/Calls/PublishCall.h
+++ b/include/rosdiscover-clang/ApiCall/Calls/PublishCall.h
@@ -18,7 +18,7 @@ public:
     return getCallExpr();
   }
 
-  const std::string getPublisher() const {
+  const std::string getPublisherName() const {
     llvm::outs() << "DEBUG [PublishCall] Publish call is : ";
     getCallExpr()->dump();
     llvm::outs() << "\n";

--- a/include/rosdiscover-clang/ApiCall/Calls/PublishCall.h
+++ b/include/rosdiscover-clang/ApiCall/Calls/PublishCall.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <llvm/ADT/APInt.h>
+
+#include "../RosApiCall.h"
+
+namespace rosdiscover {
+namespace api_call {
+
+class PublishCall : public BareRosApiCall {
+public:
+  using BareRosApiCall::BareRosApiCall;
+
+  PublishCallKind const getKind() const override {
+    return RosApiCallKind::PublishCall;
+  }
+
+  clang::Expr const * getNameExpr() const override {
+    return getCallExpr()->getArg(2);
+  }
+
+  class Finder : public RosApiCall::Finder {
+  public:
+    Finder(std::vector<RosApiCall*> &found) : RosApiCall::Finder(found) {}
+
+    const clang::ast_matchers::StatementMatcher getPattern() override {
+      using namespace clang::ast_matchers;
+      return callExpr(
+        callee(functionDecl(hasName("ros::publish")))
+      ).bind("call");
+    }
+
+  protected:
+    RosApiCall* build(clang::ast_matchers::MatchFinder::MatchResult const &result) override {
+      auto *call = result.Nodes.getNodeAs<clang::CallExpr>("call");
+      return new RosInitCall(call);
+    }
+  };
+};
+
+} // rosdiscover::api_call
+} // rosdiscover

--- a/include/rosdiscover-clang/ApiCall/Calls/PublishCall.h
+++ b/include/rosdiscover-clang/ApiCall/Calls/PublishCall.h
@@ -14,7 +14,23 @@ public:
   }
 
   clang::Expr const * getNameExpr() const override {
-    return getCallExpr()->getArg(0);
+    const auto *memberCall = clang::dyn_cast<clang::CXXMemberCallExpr>(getCallExpr());
+    if (memberCall == nullptr) {
+      llvm::outs() << "ERROR [PublishCall] publish call is no CXXMemberCallExpr\n";
+      return nullptr;
+    }
+
+    auto *callee = memberCall->getImplicitObjectArgument();
+    if (callee == nullptr) {
+    llvm::outs() << "ERROR [PublishCall] no calle on publish call\n";
+      return nullptr;
+    }
+
+    llvm::outs() << "DEBUG [PublishCall] Callee is: ";
+    callee->IgnoreImpCasts()->dump();
+    llvm::outs() << "\n";
+
+    return callee->IgnoreImpCasts();
   }
 
   class Finder : public RosApiCall::Finder {

--- a/include/rosdiscover-clang/ApiCall/Calls/PublishCall.h
+++ b/include/rosdiscover-clang/ApiCall/Calls/PublishCall.h
@@ -11,7 +11,7 @@ class PublishCall : public BareRosApiCall {
 public:
   using BareRosApiCall::BareRosApiCall;
 
-  PublishCallKind const getKind() const override {
+  RosApiCallKind const getKind() const override {
     return RosApiCallKind::PublishCall;
   }
 
@@ -33,7 +33,7 @@ public:
   protected:
     RosApiCall* build(clang::ast_matchers::MatchFinder::MatchResult const &result) override {
       auto *call = result.Nodes.getNodeAs<clang::CallExpr>("call");
-      return new PublishCallKind(call);
+      return new PublishCall(call);
     }
   };
 };

--- a/include/rosdiscover-clang/ApiCall/Calls/PublishCall.h
+++ b/include/rosdiscover-clang/ApiCall/Calls/PublishCall.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <llvm/ADT/APInt.h>
-
 #include "../RosApiCall.h"
 
 namespace rosdiscover {

--- a/include/rosdiscover-clang/ApiCall/Calls/PublishCall.h
+++ b/include/rosdiscover-clang/ApiCall/Calls/PublishCall.h
@@ -15,7 +15,8 @@ public:
   }
 
   clang::Expr const * getNameExpr() const override {
-    return getCallExpr();
+    abort();
+    return nullptr;
   }
 
   const std::string getPublisherName() const {

--- a/include/rosdiscover-clang/ApiCall/Calls/PublishCall.h
+++ b/include/rosdiscover-clang/ApiCall/Calls/PublishCall.h
@@ -16,7 +16,7 @@ public:
   }
 
   clang::Expr const * getNameExpr() const override {
-    return getCallExpr()->getArg(2);
+    return getCallExpr()->getArg(0);
   }
 
   class Finder : public RosApiCall::Finder {

--- a/include/rosdiscover-clang/ApiCall/Calls/PublishCall.h
+++ b/include/rosdiscover-clang/ApiCall/Calls/PublishCall.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "../RosApiCall.h"
+#include "./Util.h"
 
 namespace rosdiscover {
 namespace api_call {
@@ -29,33 +30,11 @@ public:
       llvm::outs() << "\n";
       return nullptr;
     }
-
-    auto *callee = memberCall->getImplicitObjectArgument();
-    if (callee == nullptr) {
-      llvm::outs() << "ERROR [PublishCall] No callee on publish call: ";
-      memberCall->dump();
-      llvm::outs() << "\n";
-      return nullptr;
-    }
-
-    const auto *member = clang::dyn_cast<clang::MemberExpr>(callee->IgnoreImpCasts());
-
-    const clang::ValueDecl *decl;
-    if (member == nullptr) {
-      const auto *declRef = clang::dyn_cast<clang::DeclRefExpr>(callee->IgnoreImpCasts());
-      if (declRef == nullptr) {
-        llvm::outs() << "ERROR [PublishCall] Callee is neither MemberExpr nor DeclRefExpr: ";
-        callee->dump();
-        llvm::outs() << "\n";
-        return nullptr;
-      }
-      decl = declRef->getDecl();
-    } else {
-      decl = member->getMemberDecl();
-    }
+    
+    const clang::ValueDecl *decl = getCallerDecl("PublishCall", memberCall);
     if (decl == nullptr) {
       llvm::outs() << "ERROR [PublishCall] Decl is null: ";
-      callee->dump();
+      memberCall->dump();
       llvm::outs() << "\n";
       return nullptr;
     }

--- a/include/rosdiscover-clang/ApiCall/Calls/PublishCall.h
+++ b/include/rosdiscover-clang/ApiCall/Calls/PublishCall.h
@@ -15,6 +15,7 @@ public:
   }
 
   clang::Expr const * getNameExpr() const override {
+    llvm::errs() << "ERROR: PublishCall does not have a NameExpr.\n";
     abort();
     return nullptr;
   }

--- a/include/rosdiscover-clang/ApiCall/Calls/PublishCall.h
+++ b/include/rosdiscover-clang/ApiCall/Calls/PublishCall.h
@@ -26,14 +26,14 @@ public:
     const clang::ast_matchers::StatementMatcher getPattern() override {
       using namespace clang::ast_matchers;
       return callExpr(
-        callee(functionDecl(hasName("ros::publish")))
+        callee(cxxMethodDecl(hasName("publish"), ofClass(hasName("ros::Publisher"))))
       ).bind("call");
     }
 
   protected:
     RosApiCall* build(clang::ast_matchers::MatchFinder::MatchResult const &result) override {
       auto *call = result.Nodes.getNodeAs<clang::CallExpr>("call");
-      return new RosInitCall(call);
+      return new PublishCallKind(call);
     }
   };
 };

--- a/include/rosdiscover-clang/ApiCall/Calls/RateSleepCall.h
+++ b/include/rosdiscover-clang/ApiCall/Calls/RateSleepCall.h
@@ -75,33 +75,7 @@ public:
     //Get the frequency argument of the rate constructor
     const auto *frequencyArg = rateConstructor->getArg(0)->IgnoreImpCasts();
     llvm::outs() << "DEBUG [RateSleepCall]: Rate found (" << frequencyArg->getStmtClassName() << ")\n";
-
-    //Try evaluating the frequency as integer.
-    clang::Expr::EvalResult resultInt;
-    if (frequencyArg->EvaluateAsInt(resultInt, Ctx)) {
-      llvm::outs() << "DEBUG [RateSleepCall]: Rate evaluated INT: (" << resultInt.Val.getInt().getSExtValue() << ")\n";
-      return new clang::APValue(resultInt.Val);
-    }
-
-    //Try evaluating the frequency as float.
-    llvm::APFloat resultFloat(0.0);
-    if (frequencyArg->EvaluateAsFloat(resultFloat, Ctx)) {
-      llvm::outs() << "DEBUG [RateSleepCall]: Rate evaluated Float: (" << resultFloat.convertToDouble() << ")\n";
-      return new clang::APValue(resultFloat);
-    }
-
-    //Try evaluating the frequency as float.
-    clang::Expr::EvalResult resultFixed;
-    if (frequencyArg->EvaluateAsFixedPoint(resultFixed, Ctx)) {
-      llvm::outs() << "DEBUG [RateSleepCall]: Rate evaluated Fixed: (" << resultFixed.Val.getFixedPoint().toString() << ")\n";
-      return new clang::APValue(resultFixed.Val.getFixedPoint());
-    } 
-  
-    //All evaluation attempts have failed.
-    llvm::outs() << "DEBUG [RateSleepCall]: Rate has unsupported type: "; 
-    frequencyArg->dump();
-    llvm::outs() << "\n";
-    return nullptr;
+    return evaluateNumber("RateSleepCall", frequencyArg, Ctx);
   }
 
   class Finder : public RosApiCall::Finder {

--- a/include/rosdiscover-clang/ApiCall/Calls/RateSleepCall.h
+++ b/include/rosdiscover-clang/ApiCall/Calls/RateSleepCall.h
@@ -17,6 +17,15 @@ public:
 
   clang::Expr const * getNameExpr() const override {
     if (const auto *E = clang::dyn_cast<clang::CXXMemberCallExpr>(getCallExpr())) {
+      if (const auto *ME = clang::dyn_cast<clang::ImplicitCastExpr>(E->getImplicitObjectArgument())) {
+        return E->getImplicitObjectArgument();
+      }
+    } 
+    return getCallExpr();
+  }
+
+  clang::Expr const * getRateExpr() const {
+    if (const auto *E = clang::dyn_cast<clang::CXXMemberCallExpr>(getCallExpr())) {
       const clang::DeclRefExpr* declRef = nullptr;
       if (const auto *ME = clang::dyn_cast<clang::ImplicitCastExpr>(E->getImplicitObjectArgument())) {
         if (const auto *SE = clang::dyn_cast<clang::DeclRefExpr>(ME->getSubExpr())) {

--- a/include/rosdiscover-clang/ApiCall/Calls/RateSleepCall.h
+++ b/include/rosdiscover-clang/ApiCall/Calls/RateSleepCall.h
@@ -20,6 +20,7 @@ public:
   }
 
   clang::Expr const * getNameExpr() const override {
+    llvm::errs() << "ERROR: RateSleepCall does not have a NameExpr.\n";
     abort();
     return nullptr;
   }

--- a/include/rosdiscover-clang/ApiCall/Calls/RateSleepCall.h
+++ b/include/rosdiscover-clang/ApiCall/Calls/RateSleepCall.h
@@ -28,7 +28,7 @@ public:
     return nullptr;
   }
 
-  clang::APValue const * getRate(const clang::ASTContext &Ctx) const {
+  clang::APValue const * getRate(const clang::ASTContext &ctx) const {
     llvm::outs() << "DEBUG [RateSleepCall]: Getting Rate for: ";
     getCallExpr()->dump();
     llvm::outs() << "\n";
@@ -75,7 +75,7 @@ public:
     //Get the frequency argument of the rate constructor
     const auto *frequencyArg = rateConstructor->getArg(0)->IgnoreImpCasts();
     llvm::outs() << "DEBUG [RateSleepCall]: Rate found (" << frequencyArg->getStmtClassName() << ")\n";
-    return evaluateNumber("RateSleepCall", frequencyArg, Ctx);
+    return evaluateNumber("RateSleepCall", frequencyArg, ctx);
   }
 
   class Finder : public RosApiCall::Finder {

--- a/include/rosdiscover-clang/ApiCall/Calls/RateSleepCall.h
+++ b/include/rosdiscover-clang/ApiCall/Calls/RateSleepCall.h
@@ -22,7 +22,7 @@ public:
         return E->getImplicitObjectArgument();
       }
     } 
-    return getCallExpr();
+    return nullptr;
   }
 
   clang::APValue getRate(const clang::ASTContext &Ctx) const {
@@ -44,30 +44,16 @@ public:
               llvm::outs() << "Rate found (" << arg->getStmtClassName() << ")\n";
               clang::Expr::EvalResult result;
               arg->EvaluateAsInt(result, Ctx);
-              llvm::outs() << "Rate evaluated (" << result.Val.getInt().getSExtValue() << ")\n";
-              return result.Val;
-              /*clang::IntegerLiteral const *int_arg;
-              if (const auto *argv = clang::dyn_cast<clang::DeclRefExpr>(arg)) {
-                llvm::outs() << "RateDecl Type: (" << argv->getDecl()->getDeclKindName() << ")\n";
-                if (auto *argdecl = clang::dyn_cast<clang::VarDecl>(argv->getDecl())) {
-                    if (argdecl->hasInit()) {
-                      llvm::outs() << "RateDecl Init: (" << argdecl->getInit()->getStmtClassName() << ")\n";
-                      if (const auto *argv = clang::dyn_cast<clang::IntegerLiteral>(argdecl->getInit())) {
-                         int_arg = argv;
-                      }
-                    }
-                }
-                llvm::errs() << "Rate unknown: " << arg->getStmtClassName() << ")\n";
-                return arg;
-
-              } else if (const auto *argv = clang::dyn_cast<clang::IntegerLiteral>(arg)) {
-                int_arg = argv;
+              if (result.Val.isInt()) {
+                llvm::outs() << "Rate evaluated INT: (" << result.Val.getInt().getSExtValue() << ")\n";
+                return result.Val;
+              } else if (result.Val.isFloat()) {
+                llvm::outs() << "Rate evaluated Float: (" << result.Val.getFloat().convertToDouble() << ")\n";
+                return result.Val;
               } else {
-                llvm::errs() << "Rate type unknown: " << arg->getStmtClassName() << ")\n";
-                return arg;
-              }
-              
-              return int_arg;*/
+                llvm::outs() << "Rate has unsupported type: (" << result.Val.getKind() << ")\n";
+                return clang::APValue();
+              }           
             }
           }
         }

--- a/include/rosdiscover-clang/ApiCall/Calls/RateSleepCall.h
+++ b/include/rosdiscover-clang/ApiCall/Calls/RateSleepCall.h
@@ -20,11 +20,7 @@ public:
   }
 
   clang::Expr const * getNameExpr() const override {
-    if (const auto *E = clang::dyn_cast<clang::CXXMemberCallExpr>(getCallExpr())) {
-      if (const auto *ME = clang::dyn_cast<clang::ImplicitCastExpr>(E->getImplicitObjectArgument())) {
-        return E->getImplicitObjectArgument();
-      }
-    } 
+    abort();
     return nullptr;
   }
 

--- a/include/rosdiscover-clang/ApiCall/Calls/RateSleepCall.h
+++ b/include/rosdiscover-clang/ApiCall/Calls/RateSleepCall.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <llvm/ADT/APInt.h>
+
+#include "../RosApiCall.h"
+
+namespace rosdiscover {
+namespace api_call {
+
+class RateSleepCall : public BareRosApiCall {
+public:
+  using BareRosApiCall::BareRosApiCall;
+
+  RosApiCallKind const getKind() const override {
+    return RosApiCallKind::RateSleepCall;
+  }
+
+  clang::Expr const * getNameExpr() const override {
+    return getCallExpr()->getArg(2);
+  }
+
+  class Finder : public RosApiCall::Finder {
+  public:
+    Finder(std::vector<RosApiCall*> &found) : RosApiCall::Finder(found) {}
+
+    const clang::ast_matchers::StatementMatcher getPattern() override {
+      using namespace clang::ast_matchers;
+      return callExpr(
+        callee(cxxMethodDecl(hasName("sleep"), ofClass(hasName("ros::Rate"))))
+      ).bind("call");
+    }
+
+  protected:
+    RosApiCall* build(clang::ast_matchers::MatchFinder::MatchResult const &result) override {
+      auto *call = result.Nodes.getNodeAs<clang::CallExpr>("call");
+      return new RateSleepCall(call);
+    }
+  };
+};
+
+} // rosdiscover::api_call
+} // rosdiscover

--- a/include/rosdiscover-clang/ApiCall/Calls/RateSleepCall.h
+++ b/include/rosdiscover-clang/ApiCall/Calls/RateSleepCall.h
@@ -44,6 +44,7 @@ public:
               llvm::outs() << "Rate found (" << arg->getStmtClassName() << ")\n";
               clang::Expr::EvalResult result;
               arg->EvaluateAsInt(result, Ctx);
+              llvm::outs() << "Rate evaluated (" << result.Val.getInt().getSExtValue() << ")\n";
               return result.Val;
               /*clang::IntegerLiteral const *int_arg;
               if (const auto *argv = clang::dyn_cast<clang::DeclRefExpr>(arg)) {
@@ -72,7 +73,7 @@ public:
         }
       }
     }
-    return nullptr;
+    return clang::APValue();
   }
 
   class Finder : public RosApiCall::Finder {

--- a/include/rosdiscover-clang/ApiCall/Calls/RateSleepCall.h
+++ b/include/rosdiscover-clang/ApiCall/Calls/RateSleepCall.h
@@ -2,6 +2,7 @@
 
 #include <clang/AST/APValue.h>
 #include <clang/AST/Expr.h>
+#include <llvm/ADT/APSInt.h>
 
 #include "../RosApiCall.h"
 
@@ -59,7 +60,7 @@ public:
         }
       }
     }
-    return clang::APValue();
+    return clang::APValue(llvm::APSInt("0"));
   }
 
   class Finder : public RosApiCall::Finder {

--- a/include/rosdiscover-clang/ApiCall/Calls/Util.h
+++ b/include/rosdiscover-clang/ApiCall/Calls/Util.h
@@ -29,7 +29,7 @@ namespace api_call {
       return new clang::APValue(resultFloat);
     }
 
-    //Try evaluating the frequency as float.
+    //Try evaluating the frequency as fixed point.
     clang::Expr::EvalResult resultFixed;
     if (expr->EvaluateAsFixedPoint(resultFixed, Ctx)) {
       llvm::outs() << "DEBUG [" << debugTag << "]: evaluated Fixed: (" << resultFixed.Val.getFixedPoint().toString() << ")\n";

--- a/include/rosdiscover-clang/ApiCall/Calls/Util.h
+++ b/include/rosdiscover-clang/ApiCall/Calls/Util.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <clang/AST/APValue.h>
+#include <clang/AST/Expr.h>
+#include <llvm/ADT/APSInt.h>
+#include <llvm/ADT/APFloat.h>
+
+#include "../RosApiCall.h"
+
+namespace rosdiscover {
+namespace api_call {
+
+  static const clang::Decl *getCallerDecl(const std::string className, const clang::CXXMemberCallExpr * memberCallExpr) {
+    const auto *caller = memberCallExpr->getImplicitObjectArgument()->IgnoreImpCasts();
+    
+    const auto *declRef = clang::dyn_cast<clang::DeclRefExpr>(caller);
+    if (declRef == nullptr || !declRef->getDecl()) {
+      llvm::outs() << "ERROR [" << className << "] Can't find declaration of CXXMemberCallExpr: ";
+      memberCallExpr->dump();
+      llvm::outs() << "\n";
+      return nullptr;
+    }
+    return declRef->getDecl();
+  }
+} // rosdiscover::api_call
+} // rosdiscover

--- a/include/rosdiscover-clang/ApiCall/Calls/Util.h
+++ b/include/rosdiscover-clang/ApiCall/Calls/Util.h
@@ -10,17 +10,56 @@
 namespace rosdiscover {
 namespace api_call {
 
-  static const clang::Decl *getCallerDecl(const std::string className, const clang::CXXMemberCallExpr * memberCallExpr) {
-    const auto *caller = memberCallExpr->getImplicitObjectArgument()->IgnoreImpCasts();
-    
-    const auto *declRef = clang::dyn_cast<clang::DeclRefExpr>(caller);
-    if (declRef == nullptr || !declRef->getDecl()) {
-      llvm::outs() << "ERROR [" << className << "] Can't find declaration of CXXMemberCallExpr: ";
-      memberCallExpr->dump();
-      llvm::outs() << "\n";
-      return nullptr;
+  static clang::APValue const * evaluateNumber(
+    const std::string debugTag, 
+    const clang::Expr *expr,
+    const clang::ASTContext &Ctx
+  ) {
+    //Try evaluating the frequency as integer.
+    clang::Expr::EvalResult resultInt;
+    if (expr->EvaluateAsInt(resultInt, Ctx)) {
+      llvm::outs() << "DEBUG [" << debugTag << "]: evaluated INT: (" << resultInt.Val.getInt().getSExtValue() << ")\n";
+      return new clang::APValue(resultInt.Val);
     }
-    return declRef->getDecl();
+
+    //Try evaluating the frequency as float.
+    llvm::APFloat resultFloat(0.0);
+    if (expr->EvaluateAsFloat(resultFloat, Ctx)) {
+      llvm::outs() << "DEBUG [" << debugTag << "]: evaluated Float: (" << resultFloat.convertToDouble() << ")\n";
+      return new clang::APValue(resultFloat);
+    }
+
+    //Try evaluating the frequency as float.
+    clang::Expr::EvalResult resultFixed;
+    if (expr->EvaluateAsFixedPoint(resultFixed, Ctx)) {
+      llvm::outs() << "DEBUG [" << debugTag << "]: evaluated Fixed: (" << resultFixed.Val.getFixedPoint().toString() << ")\n";
+      return new clang::APValue(resultFixed.Val.getFixedPoint());
+    } 
+  
+    //All evaluation attempts have failed.
+    llvm::outs() << "DEBUG [" << debugTag << "]: has unsupported type: "; 
+    expr->dump();
+    llvm::outs() << "\n";
+
+    return nullptr;
+  }
+
+  static const clang::ValueDecl *getCallerDecl(const std::string debugTag, const clang::CXXMemberCallExpr * memberCallExpr) {
+    const auto *caller = memberCallExpr->getImplicitObjectArgument()->IgnoreImpCasts();
+
+    const auto *member = clang::dyn_cast<clang::MemberExpr>(caller);
+    if (member == nullptr)
+    {
+      const auto *declRef = clang::dyn_cast<clang::DeclRefExpr>(caller);
+      if (declRef == nullptr || !declRef->getDecl()) {
+        llvm::outs() << "ERROR [" << debugTag << "] Can't find declaration of CXXMemberCallExpr: ";
+        memberCallExpr->dump();
+        llvm::outs() << "\n";
+        return nullptr;
+      }
+      return declRef->getDecl();
+    }
+    return member->getMemberDecl();
   }
 } // rosdiscover::api_call
 } // rosdiscover

--- a/include/rosdiscover-clang/ApiCall/Finder.h
+++ b/include/rosdiscover-clang/ApiCall/Finder.h
@@ -54,6 +54,7 @@ private:
     addFinder(new GetParamWithDefaultCall::Finder(calls));
     addFinder(new HasParamCall::Finder(calls));
     addFinder(new PublishCall::Finder(calls));
+    addFinder(new RateSleepCall::Finder(calls));  
     addFinder(new RosInitCall::Finder(calls));
     addFinder(new MessageFiltersSubscriberCall::Finder(calls));
     addFinder(new ServiceClientCall::Finder(calls));

--- a/include/rosdiscover-clang/ApiCall/Finder.h
+++ b/include/rosdiscover-clang/ApiCall/Finder.h
@@ -53,6 +53,7 @@ private:
     addFinder(new GetParamCall::Finder(calls));
     addFinder(new GetParamWithDefaultCall::Finder(calls));
     addFinder(new HasParamCall::Finder(calls));
+    addFinder(new PublishCall::Finder(calls));
     addFinder(new RosInitCall::Finder(calls));
     addFinder(new MessageFiltersSubscriberCall::Finder(calls));
     addFinder(new ServiceClientCall::Finder(calls));

--- a/include/rosdiscover-clang/Ast/Stmt/ApiCall.h
+++ b/include/rosdiscover-clang/Ast/Stmt/ApiCall.h
@@ -87,11 +87,11 @@ private:
 
 class RateSleep : public SymbolicRosApiCall {
 public:
-  RateSleep(std::unique_ptr<SymbolicString> name, std::unique_ptr<SymbolicInteger> rate) : SymbolicRosApiCall(std::move(name)), rate(std::move(rate)) {}
+  RateSleep(std::unique_ptr<SymbolicString> name, std::unique_ptr<SymbolicFloat> rate) : SymbolicRosApiCall(std::move(name)), rate(std::move(rate)) {}
 
   void print(llvm::raw_ostream &os) const override {
     os << "(ratesleep ";
-    rate->print(os);
+    getName()->print(os);
     os << ")";
   }
 
@@ -103,7 +103,7 @@ public:
   }
 
 private:
-  std::unique_ptr<SymbolicInteger> rate;
+  std::unique_ptr<SymbolicFloat> rate;
 };
 
 class Publish : public SymbolicRosApiCall {

--- a/include/rosdiscover-clang/Ast/Stmt/ApiCall.h
+++ b/include/rosdiscover-clang/Ast/Stmt/ApiCall.h
@@ -91,7 +91,7 @@ public:
 
   void print(llvm::raw_ostream &os) const override {
     os << "(ratesleep ";
-    getName()->print(os);
+    rate->print(os);
     os << ")";
   }
 

--- a/include/rosdiscover-clang/Ast/Stmt/ApiCall.h
+++ b/include/rosdiscover-clang/Ast/Stmt/ApiCall.h
@@ -87,23 +87,23 @@ private:
 
 class RateSleep : public SymbolicRosApiCall {
 public:
-  RateSleep(std::unique_ptr<SymbolicString> name) : SymbolicRosApiCall(std::move(name)) {}
+  RateSleep(std::unique_ptr<SymbolicString> name, std::unique_ptr<SymbolicInteger> rate) : SymbolicRosApiCall(std::move(name)), rate(std::move(rate)) {}
 
   void print(llvm::raw_ostream &os) const override {
     os << "(ratesleep ";
-    getName()->print(os);
+    rate->print(os);
     os << ")";
   }
 
   nlohmann::json toJson() const override {
     return {
       {"kind", "ratesleep"},
-      {"name", getName()->toJson()}
+      {"rate", rate->toJson()}
     };
   }
 
 private:
-  std::string const format;
+  std::unique_ptr<SymbolicInteger> rate;
 };
 
 class Publish : public SymbolicRosApiCall {

--- a/include/rosdiscover-clang/Ast/Stmt/ApiCall.h
+++ b/include/rosdiscover-clang/Ast/Stmt/ApiCall.h
@@ -108,7 +108,7 @@ private:
 
 class Publish : public SymbolicRosApiCall {
 public:
-  Publish(std::unique_ptr<SymbolicString> name) : SymbolicRosApiCall(std::move(name)) {}
+  Publish(std::unique_ptr<SymbolicString> name, std::string const &publisher) : SymbolicRosApiCall(std::move(name)), publisher(publisher) {}
 
   void print(llvm::raw_ostream &os) const override {
     os << "(publish ";
@@ -119,12 +119,12 @@ public:
   nlohmann::json toJson() const override {
     return {
       {"kind", "publish"},
-      {"name", getName()->toJson()}
+      {"publisher", publisher}
     };
   }
 
 private:
-  std::string const format;
+  std::string const publisher;
 };
 
 class ServiceCaller : public SymbolicRosApiCall {

--- a/include/rosdiscover-clang/Ast/Stmt/ApiCall.h
+++ b/include/rosdiscover-clang/Ast/Stmt/ApiCall.h
@@ -111,9 +111,7 @@ public:
   Publish(std::unique_ptr<SymbolicString> name, std::string const &publisher) : SymbolicRosApiCall(std::move(name)), publisher(publisher) {}
 
   void print(llvm::raw_ostream &os) const override {
-    os << "(publish ";
-    getName()->print(os);
-    os << ")";
+    os << "(publish " << publisher << ")";
   }
 
   nlohmann::json toJson() const override {

--- a/include/rosdiscover-clang/Ast/Stmt/ApiCall.h
+++ b/include/rosdiscover-clang/Ast/Stmt/ApiCall.h
@@ -85,6 +85,48 @@ private:
   std::string const format;
 };
 
+class RateSleep : public SymbolicRosApiCall {
+public:
+  RateSleep(std::unique_ptr<SymbolicString> name) : SymbolicRosApiCall(std::move(name)) {}
+
+  void print(llvm::raw_ostream &os) const override {
+    os << "(ratesleep ";
+    getName()->print(os);
+    os << ")";
+  }
+
+  nlohmann::json toJson() const override {
+    return {
+      {"kind", "ratesleep"},
+      {"name", getName()->toJson()}
+    };
+  }
+
+private:
+  std::string const format;
+};
+
+class Publish : public SymbolicRosApiCall {
+public:
+  Publish(std::unique_ptr<SymbolicString> name) : SymbolicRosApiCall(std::move(name)) {}
+
+  void print(llvm::raw_ostream &os) const override {
+    os << "(publish ";
+    getName()->print(os);
+    os << ")";
+  }
+
+  nlohmann::json toJson() const override {
+    return {
+      {"kind", "publish"},
+      {"name", getName()->toJson()}
+    };
+  }
+
+private:
+  std::string const format;
+};
+
 class ServiceCaller : public SymbolicRosApiCall {
 public:
   ServiceCaller(std::unique_ptr<SymbolicString> name, std::string const &format)

--- a/include/rosdiscover-clang/BackwardSymbolizer/FloatSymbolizer.h
+++ b/include/rosdiscover-clang/BackwardSymbolizer/FloatSymbolizer.h
@@ -22,7 +22,7 @@ public:
   std::unique_ptr<SymbolicFloat> symbolize(clang::Expr *expr) {
 
     if (expr == nullptr) {
-      llvm::outs() << "symbolizing (float): NULLPTR";
+      llvm::outs() << "ERROR! Symbolizing (float): NULLPTR";
       return valueBuilder.unknown();
     }
 

--- a/include/rosdiscover-clang/BackwardSymbolizer/FloatSymbolizer.h
+++ b/include/rosdiscover-clang/BackwardSymbolizer/FloatSymbolizer.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#include <string>
+#include <unordered_map>
+
+#include <clang/AST/Expr.h>
+#include <clang/AST/ExprCXX.h>
+#include <clang/AST/APValue.h>
+
+#include "../Builder/ValueBuilder.h"
+#include "../Value/Float.h"
+#include "../Helper/FindDefVisitor.h"
+
+namespace rosdiscover {
+
+class FloatSymbolizer {
+public:
+  FloatSymbolizer(
+  )
+  : valueBuilder() {}
+
+  std::unique_ptr<SymbolicFloat> symbolize(clang::Expr *expr) {
+
+    if (expr == nullptr) {
+      llvm::outs() << "symbolizing (float): NULLPTR";
+      return valueBuilder.unknown();
+    }
+
+    expr = expr->IgnoreParenCasts();
+
+    llvm::outs() << "symbolizing (float): ";
+    expr->dump();
+    llvm::outs() << "\n";
+
+    if (clang::FloatingLiteral *literal = clang::dyn_cast<clang::FloatingLiteral>(expr)) {
+      return symbolize(literal);
+    } 
+
+    llvm::outs() << "unable to symbolize expression: treating as unknown\n";
+    return valueBuilder.unknown();
+  }
+  
+  std::unique_ptr<SymbolicFloat> symbolize(clang::APValue literal) {
+    if (literal.isFloat()) {
+      return valueBuilder.floatingLiteral(literal.getFloat().convertToDouble());
+    } else if (literal.isInt()) {
+      return valueBuilder.floatingLiteral(literal.getInt().getSExtValue());
+    } else {
+      llvm::outs() << "unable to symbolize value: treating as unknown\n";
+      return valueBuilder.unknown();
+    }
+  }
+private:
+  ValueBuilder valueBuilder;
+
+  std::unique_ptr<SymbolicFloat> symbolize(clang::FloatingLiteral *literal) {
+    return valueBuilder.floatingLiteral(literal->getValue().convertToDouble());
+  }
+
+  std::unique_ptr<SymbolicFloat> symbolize(clang::IntegerLiteral *literal) {
+    return valueBuilder.floatingLiteral(literal->getValue().getSExtValue());
+  }
+
+
+};
+} // rosdiscover

--- a/include/rosdiscover-clang/BackwardSymbolizer/FloatSymbolizer.h
+++ b/include/rosdiscover-clang/BackwardSymbolizer/FloatSymbolizer.h
@@ -40,11 +40,17 @@ public:
     return valueBuilder.unknown();
   }
   
-  std::unique_ptr<SymbolicFloat> symbolize(clang::APValue literal) {
-    if (literal.isFloat()) {
-      return valueBuilder.floatingLiteral(literal.getFloat().convertToDouble());
-    } else if (literal.isInt()) {
-      return valueBuilder.floatingLiteral(literal.getInt().getSExtValue());
+  std::unique_ptr<SymbolicFloat> symbolize(const clang::APValue *literal) {
+    if (literal == nullptr) {
+      llvm::outs() << "unable to symbolize value: treating as unknown\n";
+      return valueBuilder.unknown();
+    }
+
+
+    if (literal->isFloat()) {
+      return valueBuilder.floatingLiteral(literal->getFloat().convertToDouble());
+    } else if (literal->isInt()) {
+      return valueBuilder.floatingLiteral(literal->getInt().getSExtValue());
     } else {
       llvm::outs() << "unable to symbolize value: treating as unknown\n";
       return valueBuilder.unknown();
@@ -53,11 +59,11 @@ public:
 private:
   ValueBuilder valueBuilder;
 
-  std::unique_ptr<SymbolicFloat> symbolize(clang::FloatingLiteral *literal) {
+  std::unique_ptr<SymbolicFloat> symbolize(const clang::FloatingLiteral *literal) {
     return valueBuilder.floatingLiteral(literal->getValue().convertToDouble());
   }
 
-  std::unique_ptr<SymbolicFloat> symbolize(clang::IntegerLiteral *literal) {
+  std::unique_ptr<SymbolicFloat> symbolize(const clang::IntegerLiteral *literal) {
     return valueBuilder.floatingLiteral(literal->getValue().getSExtValue());
   }
 

--- a/include/rosdiscover-clang/BackwardSymbolizer/FunctionSymbolizer.h
+++ b/include/rosdiscover-clang/BackwardSymbolizer/FunctionSymbolizer.h
@@ -600,7 +600,7 @@ private:
   ) {
     llvm::outs() << "DEBUG: symbolizing SubscribeTopicCall\n";
     return std::make_unique<Publish>(symbolizeApiCallName(apiCall), 
-        apiCall->getPublisher()
+        apiCall->getPublisherName()
     );
   }
 

--- a/include/rosdiscover-clang/BackwardSymbolizer/FunctionSymbolizer.h
+++ b/include/rosdiscover-clang/BackwardSymbolizer/FunctionSymbolizer.h
@@ -588,7 +588,7 @@ private:
     llvm::outs() << "DEBUG: symbolizing RateSleepCall\n";
     return std::make_unique<RateSleep>(
         symbolizeApiCallName(apiCall),
-        intSymbolizer.symbolize(const_cast<clang::Expr*>(apiCall->getRateExpr()))
+        intSymbolizer.symbolize(apiCall->getRate(astContext))
     );
   }
 

--- a/include/rosdiscover-clang/BackwardSymbolizer/FunctionSymbolizer.h
+++ b/include/rosdiscover-clang/BackwardSymbolizer/FunctionSymbolizer.h
@@ -589,21 +589,10 @@ private:
     api_call::RateSleepCall *apiCall
   ) {
     llvm::outs() << "DEBUG: symbolizing RateSleepCall\n";
-    auto rate = apiCall->getRate(astContext);
-    if (rate.isInt()) {
-      return std::make_unique<RateSleep>(
-          symbolizeApiCallName(apiCall),
-          floatSymbolizer.symbolize(apiCall->getRate(astContext))
-      );
-    } else if (rate.isFloat()) {
-      return std::make_unique<RateSleep>(
-          symbolizeApiCallName(apiCall),
-          floatSymbolizer.symbolize(apiCall->getRate(astContext))
-      );
-    } else {
-      llvm::outs() << "ERROR: Rate type not s\n";
-      return nullptr;
-    }
+    return std::make_unique<RateSleep>(
+        symbolizeApiCallName(apiCall),
+        floatSymbolizer.symbolize(apiCall->getRate(astContext))
+    );    
   }
 
   std::unique_ptr<SymbolicStmt> symbolizeApiCall(

--- a/include/rosdiscover-clang/BackwardSymbolizer/FunctionSymbolizer.h
+++ b/include/rosdiscover-clang/BackwardSymbolizer/FunctionSymbolizer.h
@@ -363,6 +363,10 @@ private:
         return symbolizeApiCall((BareSetParamCall*) apiCall);
       case RosApiCallKind::RosInitCall:
         return symbolizeApiCall((RosInitCall*) apiCall);
+      case RosApiCallKind::PublishCall:
+        return symbolizeApiCall((PublishCall*) apiCall);
+      case RosApiCallKind::RateSleepCall:
+        return symbolizeApiCall((RateSleepCall*) apiCall);        
       default:
         llvm::errs() << "unrecognized bare ROS API call: ";
         apiCall->print(llvm::outs());
@@ -573,6 +577,20 @@ private:
       symbolizeNodeHandleApiCallName(std::move(nodeHandle), apiCall),
       apiCall->getFormatName()
     );
+  }
+
+  std::unique_ptr<SymbolicStmt> symbolizeApiCall(
+    api_call::RateSleepCall *apiCall
+  ) {
+    llvm::outs() << "DEBUG: symbolizing SubscribeTopicCall\n";
+    return std::make_unique<RateSleep>(symbolizeApiCallName(apiCall));
+  }
+
+  std::unique_ptr<SymbolicStmt> symbolizeApiCall(
+    api_call::PublishCall *apiCall
+  ) {
+    llvm::outs() << "DEBUG: symbolizing SubscribeTopicCall\n";
+    return std::make_unique<Publish>(symbolizeApiCallName(apiCall));
   }
 
   // TODO a unique_ptr should be passed in here!

--- a/include/rosdiscover-clang/BackwardSymbolizer/FunctionSymbolizer.h
+++ b/include/rosdiscover-clang/BackwardSymbolizer/FunctionSymbolizer.h
@@ -599,7 +599,9 @@ private:
     api_call::PublishCall *apiCall
   ) {
     llvm::outs() << "DEBUG: symbolizing SubscribeTopicCall\n";
-    return std::make_unique<Publish>(symbolizeApiCallName(apiCall));
+    return std::make_unique<Publish>(symbolizeApiCallName(apiCall), 
+        apiCall->getPublisher()
+    );
   }
 
   // TODO a unique_ptr should be passed in here!

--- a/include/rosdiscover-clang/BackwardSymbolizer/FunctionSymbolizer.h
+++ b/include/rosdiscover-clang/BackwardSymbolizer/FunctionSymbolizer.h
@@ -15,6 +15,7 @@
 #include "../Value/String.h"
 #include "../Value/Value.h"
 #include "StringSymbolizer.h"
+#include "IntSymbolizer.h"
 
 namespace rosdiscover {
 
@@ -79,6 +80,7 @@ private:
       functionCalls(functionCalls),
       apiCallToVar(),
       stringSymbolizer(astContext, apiCallToVar),
+      intSymbolizer(),
       valueBuilder(),
       symbolicArgNames(symbolicArgNames),
       callbacks(callbacks)
@@ -93,6 +95,7 @@ private:
   std::vector<clang::Expr *> &functionCalls;
   std::unordered_map<clang::Expr const *, SymbolicVariable *> apiCallToVar;
   StringSymbolizer stringSymbolizer;
+  IntSymbolizer intSymbolizer;
   ValueBuilder valueBuilder;
   std::unordered_set<std::string> symbolicArgNames;
   [[maybe_unused]] std::vector<Callback*> &callbacks;
@@ -583,7 +586,10 @@ private:
     api_call::RateSleepCall *apiCall
   ) {
     llvm::outs() << "DEBUG: symbolizing RateSleepCall\n";
-    return std::make_unique<RateSleep>(symbolizeApiCallName(apiCall));
+    return std::make_unique<RateSleep>(
+        symbolizeApiCallName(apiCall),
+        intSymbolizer.symbolize(const_cast<clang::Expr*>(apiCall->getRateExpr()))
+    );
   }
 
   std::unique_ptr<SymbolicStmt> symbolizeApiCall(

--- a/include/rosdiscover-clang/BackwardSymbolizer/FunctionSymbolizer.h
+++ b/include/rosdiscover-clang/BackwardSymbolizer/FunctionSymbolizer.h
@@ -582,7 +582,7 @@ private:
   std::unique_ptr<SymbolicStmt> symbolizeApiCall(
     api_call::RateSleepCall *apiCall
   ) {
-    llvm::outs() << "DEBUG: symbolizing SubscribeTopicCall\n";
+    llvm::outs() << "DEBUG: symbolizing RateSleepCall\n";
     return std::make_unique<RateSleep>(symbolizeApiCallName(apiCall));
   }
 

--- a/include/rosdiscover-clang/BackwardSymbolizer/IntSymbolizer.h
+++ b/include/rosdiscover-clang/BackwardSymbolizer/IntSymbolizer.h
@@ -40,13 +40,23 @@ public:
     return valueBuilder.unknown();
   }
   
-  std::unique_ptr<SymbolicInteger> symbolize(clang::APValue literal) {
-    return valueBuilder.integerLiteral(literal.getInt().getSExtValue());
+  std::unique_ptr<SymbolicInteger> symbolize(const clang::APValue *literal) {
+    if (literal == nullptr) {
+      llvm::outs() << "unable to symbolize value: treating as unknown\n";
+      return valueBuilder.unknown();
+    }
+
+    return valueBuilder.integerLiteral(literal->getInt().getSExtValue());
   }
 private:
   ValueBuilder valueBuilder;
 
-  std::unique_ptr<SymbolicInteger> symbolize(clang::IntegerLiteral *literal) {
+  std::unique_ptr<SymbolicInteger> symbolize(const clang::IntegerLiteral *literal) {
+    if (literal == nullptr) {
+      llvm::outs() << "unable to symbolize value: treating as unknown\n";
+      return valueBuilder.unknown();
+    }
+
     return valueBuilder.integerLiteral(literal->getValue().getSExtValue());
   }
 

--- a/include/rosdiscover-clang/BackwardSymbolizer/IntSymbolizer.h
+++ b/include/rosdiscover-clang/BackwardSymbolizer/IntSymbolizer.h
@@ -33,7 +33,10 @@ public:
     llvm::outs() << "unable to symbolize expression: treating as unknown\n";
     return valueBuilder.unknown();
   }
-
+  
+  std::unique_ptr<SymbolicInteger> symbolize(clang::APValue literal) {
+    return valueBuilder.integerLiteral(literal.getInt().getSExtValue());
+  }
 private:
   ValueBuilder valueBuilder;
 
@@ -41,8 +44,6 @@ private:
     return valueBuilder.integerLiteral(literal->getValue().getSExtValue());
   }
 
-  std::unique_ptr<SymbolicInteger> symbolize(clang::APValue literal) {
-    return valueBuilder.integerLiteral(literal->getInt()->getSExtValue());
-  }
+
 };
 } // rosdiscover

--- a/include/rosdiscover-clang/BackwardSymbolizer/IntSymbolizer.h
+++ b/include/rosdiscover-clang/BackwardSymbolizer/IntSymbolizer.h
@@ -20,9 +20,15 @@ public:
   : valueBuilder() {}
 
   std::unique_ptr<SymbolicInteger> symbolize(clang::Expr *expr) {
+
+    if (expr == nullptr) {
+      llvm::outs() << "symbolizing (int): NULLPTR";
+      return valueBuilder.unknown();
+    }
+
     expr = expr->IgnoreParenCasts();
 
-    llvm::outs() << "symbolizing: ";
+    llvm::outs() << "symbolizing (int): ";
     expr->dump();
     llvm::outs() << "\n";
 

--- a/include/rosdiscover-clang/BackwardSymbolizer/IntSymbolizer.h
+++ b/include/rosdiscover-clang/BackwardSymbolizer/IntSymbolizer.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <string>
+#include <unordered_map>
+
+#include <clang/AST/Expr.h>
+#include <clang/AST/ExprCXX.h>
+#include <clang/AST/APValue.h>
+
+#include "../Builder/ValueBuilder.h"
+#include "../Value/String.h"
+#include "../Helper/FindDefVisitor.h"
+
+namespace rosdiscover {
+
+class IntSymbolizer {
+public:
+  IntSymbolizer(
+  )
+  : valueBuilder() {}
+
+  std::unique_ptr<SymbolicInteger> symbolize(clang::Expr *expr) {
+    expr = expr->IgnoreParenCasts();
+
+    llvm::outs() << "symbolizing: ";
+    expr->dump();
+    llvm::outs() << "\n";
+
+    if (clang::IntegerLiteral *literal = clang::dyn_cast<clang::IntegerLiteral>(expr)) {
+      return symbolize(literal);
+    } 
+
+    llvm::outs() << "unable to symbolize expression: treating as unknown\n";
+    return valueBuilder.unknown();
+  }
+
+private:
+  ValueBuilder valueBuilder;
+
+  std::unique_ptr<SymbolicInteger> symbolize(clang::IntegerLiteral *literal) {
+    return valueBuilder.integerLiteral(literal->getValue().getSExtValue());
+  }
+
+  std::unique_ptr<SymbolicInteger> symbolize(clang::APValue literal) {
+    return valueBuilder.integerLiteral(literal->getInt()->getSExtValue());
+  }
+};
+} // rosdiscover

--- a/include/rosdiscover-clang/BackwardSymbolizer/IntSymbolizer.h
+++ b/include/rosdiscover-clang/BackwardSymbolizer/IntSymbolizer.h
@@ -22,7 +22,7 @@ public:
   std::unique_ptr<SymbolicInteger> symbolize(clang::Expr *expr) {
 
     if (expr == nullptr) {
-      llvm::outs() << "symbolizing (int): NULLPTR";
+      llvm::outs() << "ERROR! Symbolizing (int): NULLPTR";
       return valueBuilder.unknown();
     }
 

--- a/include/rosdiscover-clang/BackwardSymbolizer/StringSymbolizer.h
+++ b/include/rosdiscover-clang/BackwardSymbolizer/StringSymbolizer.h
@@ -50,6 +50,8 @@ public:
       return symbolize(declRefExpr);
     } else if (clang::StringLiteral *literal = clang::dyn_cast<clang::StringLiteral>(expr)) {
       return symbolize(literal);
+    } else if (clang::IntegerLiteral *literal = clang::dyn_cast<clang::IntegerLiteral>(expr)) {
+      return symbolize(literal);
     } else if (clang::ImplicitCastExpr *implicitCastExpr = clang::dyn_cast<clang::ImplicitCastExpr>(expr)) {
       return symbolize(implicitCastExpr);
     } else if (clang::CXXConstructExpr *constructExpr = clang::dyn_cast<clang::CXXConstructExpr>(expr)) {
@@ -71,6 +73,10 @@ private:
 
   std::unique_ptr<SymbolicString> symbolize(clang::StringLiteral *literal) {
     return valueBuilder.stringLiteral(literal->getString().str());
+  }
+
+  std::unique_ptr<SymbolicString> symbolize(clang::IntegerLiteral *literal) {
+    return valueBuilder.stringLiteral(std::to_string(literal->getValue().getSExtValue()));
   }
 
   std::unique_ptr<SymbolicString> symbolize(clang::CXXConstructExpr *expr) {

--- a/include/rosdiscover-clang/BackwardSymbolizer/StringSymbolizer.h
+++ b/include/rosdiscover-clang/BackwardSymbolizer/StringSymbolizer.h
@@ -22,9 +22,14 @@ public:
   : astContext(astContext), apiCallToVar(apiCallToVar), valueBuilder() {}
 
   std::unique_ptr<SymbolicString> symbolize(clang::Expr *expr) {
+    if (expr == nullptr) {
+      llvm::outs() << "symbolizing (str): NULLPTR";
+      return valueBuilder.unknown();
+    }
+
     expr = expr->IgnoreParenCasts();
 
-    llvm::outs() << "symbolizing: ";
+    llvm::outs() << "symbolizing (str): ";
     expr->dump();
     llvm::outs() << "\n";
 

--- a/include/rosdiscover-clang/BackwardSymbolizer/StringSymbolizer.h
+++ b/include/rosdiscover-clang/BackwardSymbolizer/StringSymbolizer.h
@@ -23,7 +23,7 @@ public:
 
   std::unique_ptr<SymbolicString> symbolize(clang::Expr *expr) {
     if (expr == nullptr) {
-      llvm::outs() << "symbolizing (str): NULLPTR";
+      llvm::outs() << "ERROR! Symbolizing (str): NULLPTR";
       return valueBuilder.unknown();
     }
 

--- a/include/rosdiscover-clang/Builder/ValueBuilder.h
+++ b/include/rosdiscover-clang/Builder/ValueBuilder.h
@@ -5,6 +5,7 @@
 #include "../Value/Bool.h"
 #include "../Value/String.h"
 #include "../Value/Int.h"
+#include "../Value/Float.h"
 #include "../Value/Value.h"
 #include "../Ast/Decl/Decls.h"
 
@@ -19,6 +20,10 @@ public:
   std::unique_ptr<StringLiteral> stringLiteral(std::string const &string) const {
     return std::make_unique<StringLiteral>(string);
   }
+
+  std::unique_ptr<FloatingLiteral> floatingLiteral(double const &i) const {
+    return std::make_unique<FloatingLiteral>(i);
+  }  
 
   std::unique_ptr<IntegerLiteral> integerLiteral(int const &i) const {
     return std::make_unique<IntegerLiteral>(i);

--- a/include/rosdiscover-clang/Builder/ValueBuilder.h
+++ b/include/rosdiscover-clang/Builder/ValueBuilder.h
@@ -4,6 +4,7 @@
 
 #include "../Value/Bool.h"
 #include "../Value/String.h"
+#include "../Value/Int.h"
 #include "../Value/Value.h"
 #include "../Ast/Decl/Decls.h"
 
@@ -18,6 +19,10 @@ public:
   std::unique_ptr<StringLiteral> stringLiteral(std::string const &string) const {
     return std::make_unique<StringLiteral>(string);
   }
+
+  std::unique_ptr<IntegerLiteral> integerLiteral(int const &i) const {
+    return std::make_unique<IntegerLiteral>(i);
+  }  
 
   std::unique_ptr<NodeName> nodeName() const {
     return std::make_unique<NodeName>();

--- a/include/rosdiscover-clang/Value/Float.h
+++ b/include/rosdiscover-clang/Value/Float.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <string>
+
+#include "Value.h"
+
+namespace rosdiscover {
+
+class FloatingLiteral : public virtual SymbolicFloat {
+public:
+  FloatingLiteral(double const &literal) : literal(literal) {}
+  ~FloatingLiteral() {}
+
+  static FloatingLiteral* create(double const &literal) {
+    return new FloatingLiteral(literal);
+  }
+
+  void print(llvm::raw_ostream &os) const override {
+    os << "\"" << literal << "\"";
+  }
+
+  nlohmann::json toJson() const override {
+    return {
+      {"kind", "float-literal"},
+      {"literal", literal}
+    };
+  }
+
+private:
+  double const literal;
+};
+
+} // rosdiscover

--- a/include/rosdiscover-clang/Value/Int.h
+++ b/include/rosdiscover-clang/Value/Int.h
@@ -8,10 +8,10 @@ namespace rosdiscover {
 
 class IntegerLiteral : public virtual SymbolicInteger {
 public:
-  IntegerLiteral(int const &literal) : literal(literal) {}
+  IntegerLiteral(long const &literal) : literal(literal) {}
   ~IntegerLiteral() {}
 
-  static IntegerLiteral* create(int const &literal) {
+  static IntegerLiteral* create(long const &literal) {
     return new IntegerLiteral(literal);
   }
 
@@ -27,7 +27,7 @@ public:
   }
 
 private:
-  int const literal;
+  long const literal;
 };
 
 } // rosdiscover

--- a/include/rosdiscover-clang/Value/Int.h
+++ b/include/rosdiscover-clang/Value/Int.h
@@ -6,7 +6,7 @@
 
 namespace rosdiscover {
 
-class IntegerLiteral : public virtual SymbolicString {
+class IntegerLiteral : public virtual SymbolicInteger {
 public:
   IntegerLiteral(int const &literal) : literal(literal) {}
   ~IntegerLiteral() {}

--- a/include/rosdiscover-clang/Value/Int.h
+++ b/include/rosdiscover-clang/Value/Int.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <string>
+
+#include "Value.h"
+
+namespace rosdiscover {
+
+class IntegerLiteral : public virtual SymbolicString {
+public:
+  IntegerLiteral(int const &literal) : literal(literal) {}
+  ~IntegerLiteral() {}
+
+  static IntegerLiteral* create(int const &literal) {
+    return new IntegerLiteral(literal);
+  }
+
+  void print(llvm::raw_ostream &os) const override {
+    os << "\"" << literal << "\"";
+  }
+
+  nlohmann::json toJson() const override {
+    return {
+      {"kind", "integer-literal"},
+      {"literal", literal}
+    };
+  }
+
+private:
+  int const literal;
+};
+
+} // rosdiscover

--- a/include/rosdiscover-clang/Value/Value.h
+++ b/include/rosdiscover-clang/Value/Value.h
@@ -11,6 +11,7 @@ namespace rosdiscover {
 enum class SymbolicValueType {
   String,
   Bool,
+  Float,
   Integer,
   Unsupported,
   NodeHandle
@@ -35,6 +36,9 @@ public:
       return SymbolicValueType::Bool;
     } else if (typeName == "int") {
       return SymbolicValueType::Integer;
+    } else if (typeName == "float" 
+            || typeName == "double") {
+      return SymbolicValueType::Float;
     } else if (typeName == "ros::NodeHandle"
             || typeName == "ros::NodeHandle &"
             || typeName == "ros::NodeHandle *") {
@@ -50,6 +54,8 @@ public:
         return "string";
       case SymbolicValueType::Bool:
         return "bool";
+      case SymbolicValueType::Float:
+        return "float";        
       case SymbolicValueType::Integer:
         return "integer";
       case SymbolicValueType::Unsupported:
@@ -64,6 +70,8 @@ class SymbolicString : public virtual SymbolicValue {};
 
 class SymbolicBool : public virtual SymbolicValue {};
 
+class SymbolicFloat : public virtual SymbolicValue {};
+
 class SymbolicInteger : public virtual SymbolicValue {};
 
 class SymbolicNodeHandle :
@@ -75,6 +83,7 @@ class SymbolicUnknown :
   public virtual SymbolicString,
   public virtual SymbolicBool,
   public virtual SymbolicInteger,
+  public virtual SymbolicFloat,
   public virtual SymbolicNodeHandle
 {
 public:
@@ -99,6 +108,7 @@ public:
 class SymbolicArg:
   public virtual SymbolicString,
   public virtual SymbolicBool,
+  public virtual SymbolicFloat,
   public virtual SymbolicInteger,
   public virtual SymbolicNodeHandle
 {


### PR DESCRIPTION
This PR adds API Call finders for `pub.publish(msg)` and `rate.sleep()`.

To do this, I also added basic support for Integers and Floats to the recovery engine.

The `PublishCall` finder is looking for calls to `publish` on `ros::Publisher` and extracts the identifier name of the caller object.
The output looks like this:
```
{
  "kind": "publish",
  "publisher": "cmd_vel_pub_",
  "source-location": "</ros_ws/src/turtlebot_apps/turtlebot_actions/src/turtlebot_move_action_server.cpp:150:7, col:36>"
},
```

The `RateSleepCall` finder is looking for a call to `sleep` on `ros::Rate` and looks for the initialization frequency of the constructor of the rate object. 
The output looks like this:
```
{
  "kind": "ratesleep",
  "rate": {
    "kind": "float-literal",
    "literal": 25.0
  },
  "source-location": "</ros_ws/src/turtlebot_apps/turtlebot_actions/src/turtlebot_move_action_server.cpp:151:7, col:18>"
},
```