### PR TITLE
Introduce NamedSymbolicRosApiCall and NamedRosApiCall

### DIFF
--- a/include/rosdiscover-clang/ApiCall/Calls/AdvertiseServiceCall.h
+++ b/include/rosdiscover-clang/ApiCall/Calls/AdvertiseServiceCall.h
@@ -9,7 +9,7 @@
 namespace rosdiscover {
 namespace api_call {
 
-class AdvertiseServiceCall : public NodeHandleRosApiCall {
+class AdvertiseServiceCall : public NodeHandleRosApiCall, public NamedRosApiCall  {
 public:
   using NodeHandleRosApiCall::NodeHandleRosApiCall;
 

--- a/include/rosdiscover-clang/ApiCall/Calls/AdvertiseTopicCall.h
+++ b/include/rosdiscover-clang/ApiCall/Calls/AdvertiseTopicCall.h
@@ -6,7 +6,7 @@
 namespace rosdiscover {
 namespace api_call {
 
-class AdvertiseTopicCall : public NodeHandleRosApiCall {
+class AdvertiseTopicCall : public NodeHandleRosApiCall, public NamedRosApiCall {
 public:
   using NodeHandleRosApiCall::NodeHandleRosApiCall;
 

--- a/include/rosdiscover-clang/ApiCall/Calls/BareDeleteParamCall.h
+++ b/include/rosdiscover-clang/ApiCall/Calls/BareDeleteParamCall.h
@@ -5,7 +5,7 @@
 namespace rosdiscover {
 namespace api_call {
 
-class BareDeleteParamCall : public BareRosApiCall {
+class BareDeleteParamCall : public BareRosApiCall, public NamedRosApiCall {
 public:
   using BareRosApiCall::BareRosApiCall;
 

--- a/include/rosdiscover-clang/ApiCall/Calls/BareGetParamCachedCall.h
+++ b/include/rosdiscover-clang/ApiCall/Calls/BareGetParamCachedCall.h
@@ -5,7 +5,7 @@
 namespace rosdiscover {
 namespace api_call {
 
-class BareGetParamCachedCall : public BareRosApiCall {
+class BareGetParamCachedCall : public BareRosApiCall, public NamedRosApiCall {
 public:
   using BareRosApiCall::BareRosApiCall;
 

--- a/include/rosdiscover-clang/ApiCall/Calls/BareGetParamCall.h
+++ b/include/rosdiscover-clang/ApiCall/Calls/BareGetParamCall.h
@@ -5,7 +5,7 @@
 namespace rosdiscover {
 namespace api_call {
 
-class BareGetParamCall : public BareRosApiCall {
+class BareGetParamCall : public BareRosApiCall, public NamedRosApiCall {
 public:
   using BareRosApiCall::BareRosApiCall;
 

--- a/include/rosdiscover-clang/ApiCall/Calls/BareGetParamWithDefaultCall.h
+++ b/include/rosdiscover-clang/ApiCall/Calls/BareGetParamWithDefaultCall.h
@@ -6,7 +6,7 @@ namespace rosdiscover {
 namespace api_call {
 
 
-class BareGetParamWithDefaultCall : public BareRosApiCall {
+class BareGetParamWithDefaultCall : public BareRosApiCall, public NamedRosApiCall {
 public:
   using BareRosApiCall::BareRosApiCall;
 

--- a/include/rosdiscover-clang/ApiCall/Calls/BareHasParamCall.h
+++ b/include/rosdiscover-clang/ApiCall/Calls/BareHasParamCall.h
@@ -5,7 +5,7 @@
 namespace rosdiscover {
 namespace api_call {
 
-class BareHasParamCall : public BareRosApiCall {
+class BareHasParamCall : public BareRosApiCall, public NamedRosApiCall {
 public:
   using BareRosApiCall::BareRosApiCall;
 

--- a/include/rosdiscover-clang/ApiCall/Calls/BareServiceCall.h
+++ b/include/rosdiscover-clang/ApiCall/Calls/BareServiceCall.h
@@ -6,7 +6,7 @@
 namespace rosdiscover {
 namespace api_call {
 
-class BareServiceCall : public BareRosApiCall {
+class BareServiceCall : public BareRosApiCall, public NamedRosApiCall {
 public:
   using BareRosApiCall::BareRosApiCall;
 

--- a/include/rosdiscover-clang/ApiCall/Calls/BareSetParamCall.h
+++ b/include/rosdiscover-clang/ApiCall/Calls/BareSetParamCall.h
@@ -5,7 +5,7 @@
 namespace rosdiscover {
 namespace api_call {
 
-class BareSetParamCall : public BareRosApiCall {
+class BareSetParamCall : public BareRosApiCall, public NamedRosApiCall {
 public:
   using BareRosApiCall::BareRosApiCall;
 

--- a/include/rosdiscover-clang/ApiCall/Calls/DeleteParamCall.h
+++ b/include/rosdiscover-clang/ApiCall/Calls/DeleteParamCall.h
@@ -5,7 +5,7 @@
 namespace rosdiscover {
 namespace api_call {
 
-class DeleteParamCall : public NodeHandleRosApiCall {
+class DeleteParamCall : public NodeHandleRosApiCall, public NamedRosApiCall {
 public:
   using NodeHandleRosApiCall::NodeHandleRosApiCall;
 

--- a/include/rosdiscover-clang/ApiCall/Calls/GetParamCachedCall.h
+++ b/include/rosdiscover-clang/ApiCall/Calls/GetParamCachedCall.h
@@ -5,7 +5,7 @@
 namespace rosdiscover {
 namespace api_call {
 
-class GetParamCachedCall : public NodeHandleRosApiCall {
+class GetParamCachedCall : public NodeHandleRosApiCall, public NamedRosApiCall {
 public:
   using NodeHandleRosApiCall::NodeHandleRosApiCall;
 

--- a/include/rosdiscover-clang/ApiCall/Calls/GetParamCall.h
+++ b/include/rosdiscover-clang/ApiCall/Calls/GetParamCall.h
@@ -5,7 +5,7 @@
 namespace rosdiscover {
 namespace api_call {
 
-class GetParamCall : public NodeHandleRosApiCall {
+class GetParamCall : public NodeHandleRosApiCall, public NamedRosApiCall {
 public:
   using NodeHandleRosApiCall::NodeHandleRosApiCall;
 

--- a/include/rosdiscover-clang/ApiCall/Calls/GetParamWithDefaultCall.h
+++ b/include/rosdiscover-clang/ApiCall/Calls/GetParamWithDefaultCall.h
@@ -5,7 +5,7 @@
 namespace rosdiscover {
 namespace api_call {
 
-class GetParamWithDefaultCall : public NodeHandleRosApiCall {
+class GetParamWithDefaultCall : public NodeHandleRosApiCall, public NamedRosApiCall {
 public:
   using NodeHandleRosApiCall::NodeHandleRosApiCall;
 

--- a/include/rosdiscover-clang/ApiCall/Calls/HasParamCall.h
+++ b/include/rosdiscover-clang/ApiCall/Calls/HasParamCall.h
@@ -5,7 +5,7 @@
 namespace rosdiscover {
 namespace api_call {
 
-class HasParamCall : public NodeHandleRosApiCall {
+class HasParamCall : public NodeHandleRosApiCall, public NamedRosApiCall {
 public:
   using NodeHandleRosApiCall::NodeHandleRosApiCall;
 

--- a/include/rosdiscover-clang/ApiCall/Calls/MessageFiltersSubscriberCall.h
+++ b/include/rosdiscover-clang/ApiCall/Calls/MessageFiltersSubscriberCall.h
@@ -6,7 +6,7 @@
 namespace rosdiscover {
 namespace api_call {
 
-class MessageFiltersSubscriberCall : public RosApiCallWithNodeHandle {
+class MessageFiltersSubscriberCall : public RosApiCallWithNodeHandle, public NamedRosApiCall {
 public:
   using RosApiCallWithNodeHandle::RosApiCallWithNodeHandle;
 

--- a/include/rosdiscover-clang/ApiCall/Calls/PublishCall.h
+++ b/include/rosdiscover-clang/ApiCall/Calls/PublishCall.h
@@ -14,12 +14,6 @@ public:
     return RosApiCallKind::PublishCall;
   }
 
-  clang::Expr const * getNameExpr() const override {
-    llvm::errs() << "ERROR: PublishCall does not have a NameExpr.\n";
-    abort();
-    return nullptr;
-  }
-
   const std::string getPublisherName() const {
     llvm::outs() << "DEBUG [PublishCall] Publish call is : ";
     getCallExpr()->dump();

--- a/include/rosdiscover-clang/ApiCall/Calls/RateSleepCall.h
+++ b/include/rosdiscover-clang/ApiCall/Calls/RateSleepCall.h
@@ -19,12 +19,6 @@ public:
     return RosApiCallKind::RateSleepCall;
   }
 
-  clang::Expr const * getNameExpr() const override {
-    llvm::errs() << "ERROR: RateSleepCall does not have a NameExpr.\n";
-    abort();
-    return nullptr;
-  }
-
   clang::APValue const * getRate(const clang::ASTContext &ctx) const {
     llvm::outs() << "DEBUG [RateSleepCall]: Getting Rate for: ";
     getCallExpr()->dump();

--- a/include/rosdiscover-clang/ApiCall/Calls/RosInitCall.h
+++ b/include/rosdiscover-clang/ApiCall/Calls/RosInitCall.h
@@ -7,7 +7,7 @@
 namespace rosdiscover {
 namespace api_call {
 
-class RosInitCall : public BareRosApiCall {
+class RosInitCall : public BareRosApiCall, public NamedRosApiCall {
 public:
   using BareRosApiCall::BareRosApiCall;
 

--- a/include/rosdiscover-clang/ApiCall/Calls/ServiceClientCall.h
+++ b/include/rosdiscover-clang/ApiCall/Calls/ServiceClientCall.h
@@ -8,7 +8,7 @@
 namespace rosdiscover {
 namespace api_call {
 
-class ServiceClientCall : public NodeHandleRosApiCall {
+class ServiceClientCall : public NodeHandleRosApiCall, public NamedRosApiCall {
 public:
   using NodeHandleRosApiCall::NodeHandleRosApiCall;
 

--- a/include/rosdiscover-clang/ApiCall/Calls/SetParamCall.h
+++ b/include/rosdiscover-clang/ApiCall/Calls/SetParamCall.h
@@ -5,7 +5,7 @@
 namespace rosdiscover {
 namespace api_call {
 
-class SetParamCall : public NodeHandleRosApiCall {
+class SetParamCall : public NodeHandleRosApiCall, public NamedRosApiCall {
 public:
   using NodeHandleRosApiCall::NodeHandleRosApiCall;
 

--- a/include/rosdiscover-clang/ApiCall/Calls/SubscribeTopicCall.h
+++ b/include/rosdiscover-clang/ApiCall/Calls/SubscribeTopicCall.h
@@ -8,7 +8,7 @@
 namespace rosdiscover {
 namespace api_call {
 
-class SubscribeTopicCall : public NodeHandleRosApiCall {
+class SubscribeTopicCall : public NodeHandleRosApiCall, public NamedRosApiCall {
 public:
   using NodeHandleRosApiCall::NodeHandleRosApiCall;
 

--- a/include/rosdiscover-clang/ApiCall/RosApiCall.h
+++ b/include/rosdiscover-clang/ApiCall/RosApiCall.h
@@ -34,9 +34,6 @@ public:
     return nullptr;
   }
 
-  /** Returns the expression that provides the name associated with this call. */
-  virtual clang::Expr const * getNameExpr() const = 0;
-
   /** Indicates whether or not this API call has an associated node handle. */
   virtual bool hasNodeHandle() const = 0;
 
@@ -119,6 +116,14 @@ private:
   CallOrConstructExpr const *call;
 }; // RosApiCall
 
+
+class NamedRosApiCall {
+public:
+
+  /** Returns the expression that provides the name associated with this call. */
+  virtual clang::Expr const * getNameExpr() const = 0;
+  
+}; // NamedRosApiCall
 
 class BareRosApiCall : public RosApiCall {
 public:

--- a/include/rosdiscover-clang/Ast/Stmt/ApiCall.h
+++ b/include/rosdiscover-clang/Ast/Stmt/ApiCall.h
@@ -9,21 +9,26 @@ namespace rosdiscover {
 class SymbolicRosApiCall : public virtual SymbolicStmt {
 public:
   ~SymbolicRosApiCall(){}
+};
+
+class NamedSymbolicRosApiCall : public virtual SymbolicRosApiCall {
+public:
+  ~NamedSymbolicRosApiCall(){}
 
   SymbolicString const * getName() const {
     return name.get();
   }
 
 protected:
-  SymbolicRosApiCall(std::unique_ptr<SymbolicString> name) : name(std::move(name)) {}
+  NamedSymbolicRosApiCall(std::unique_ptr<SymbolicString> name) : name(std::move(name)) {}
 
 private:
   std::unique_ptr<SymbolicString> name;
 };
 
-class RosInit : public SymbolicRosApiCall {
+class RosInit : public NamedSymbolicRosApiCall {
 public:
-  RosInit(std::unique_ptr<SymbolicString> name) : SymbolicRosApiCall(std::move(name)) {}
+  RosInit(std::unique_ptr<SymbolicString> name) : NamedSymbolicRosApiCall(std::move(name)) {}
 
   void print(llvm::raw_ostream &os) const override {
     os << "(ros-init ";
@@ -39,10 +44,10 @@ public:
   }
 };
 
-class Publisher : public SymbolicRosApiCall {
+class Publisher : public NamedSymbolicRosApiCall {
 public:
   Publisher(std::unique_ptr<SymbolicString> name, std::string const &format)
-  : SymbolicRosApiCall(std::move(name)), format(format) {}
+  : NamedSymbolicRosApiCall(std::move(name)), format(format) {}
 
   void print(llvm::raw_ostream &os) const override {
     os << "(publishes-to ";
@@ -62,10 +67,10 @@ private:
   std::string const format;
 };
 
-class Subscriber : public SymbolicRosApiCall {
+class Subscriber : public NamedSymbolicRosApiCall {
 public:
   Subscriber(std::unique_ptr<SymbolicString> name, std::string const &format, std::unique_ptr<SymbolicStmt> callback)
-  : SymbolicRosApiCall(std::move(name)), format(format), callback(std::move(callback)) {}
+  : NamedSymbolicRosApiCall(std::move(name)), format(format), callback(std::move(callback)) {}
 
   void print(llvm::raw_ostream &os) const override {
     os << "(subscribes-to ";
@@ -89,7 +94,7 @@ private:
 
 class RateSleep : public SymbolicRosApiCall {
 public:
-  RateSleep(std::unique_ptr<SymbolicString> name, std::unique_ptr<SymbolicFloat> rate) : SymbolicRosApiCall(std::move(name)), rate(std::move(rate)) {}
+  RateSleep(std::unique_ptr<SymbolicFloat> rate) : SymbolicRosApiCall(), rate(std::move(rate)) {}
 
   void print(llvm::raw_ostream &os) const override {
     os << "(ratesleep ";
@@ -110,7 +115,7 @@ private:
 
 class Publish : public SymbolicRosApiCall {
 public:
-  Publish(std::unique_ptr<SymbolicString> name, std::string const &publisher) : SymbolicRosApiCall(std::move(name)), publisher(publisher) {}
+  Publish(std::string const &publisher) : SymbolicRosApiCall(), publisher(publisher) {}
 
   void print(llvm::raw_ostream &os) const override {
     os << "(publish " << publisher << ")";
@@ -127,10 +132,10 @@ private:
   std::string const publisher;
 };
 
-class ServiceCaller : public SymbolicRosApiCall {
+class ServiceCaller : public NamedSymbolicRosApiCall {
 public:
   ServiceCaller(std::unique_ptr<SymbolicString> name, std::string const &format)
-  : SymbolicRosApiCall(std::move(name)), format(format) {}
+  : NamedSymbolicRosApiCall(std::move(name)), format(format) {}
 
   void print(llvm::raw_ostream &os) const override {
     os << "(calls-service ";
@@ -150,13 +155,13 @@ private:
   std::string const format;
 };
 
-class ServiceProvider : public SymbolicRosApiCall {
+class ServiceProvider : public NamedSymbolicRosApiCall {
 public:
   ServiceProvider(
     std::unique_ptr<SymbolicString> name,
     std::string const &requestFormat,
     std::string const &responseFormat
-  ) : SymbolicRosApiCall(std::move(name)),
+  ) : NamedSymbolicRosApiCall(std::move(name)),
       requestFormat(requestFormat),
       responseFormat(responseFormat)
   {}
@@ -182,11 +187,11 @@ private:
 };
 
 class ReadParam :
-  public SymbolicRosApiCall,
+  public NamedSymbolicRosApiCall,
   public virtual SymbolicValue
 {
 public:
-  ReadParam(std::unique_ptr<SymbolicString> name) : SymbolicRosApiCall(std::move(name)) {}
+  ReadParam(std::unique_ptr<SymbolicString> name) : NamedSymbolicRosApiCall(std::move(name)) {}
 
   void print(llvm::raw_ostream &os) const override {
     os << "(reads-param ";
@@ -202,10 +207,10 @@ public:
   }
 };
 
-class WriteParam : public SymbolicRosApiCall {
+class WriteParam : public NamedSymbolicRosApiCall {
 public:
   WriteParam(std::unique_ptr<SymbolicString> name, std::unique_ptr<SymbolicValue> value)
-    : SymbolicRosApiCall(std::move(name)), value(std::move(value))
+    : NamedSymbolicRosApiCall(std::move(name)), value(std::move(value))
   {}
 
   void print(llvm::raw_ostream &os) const override {
@@ -226,9 +231,9 @@ private:
   std::unique_ptr<SymbolicValue> value;
 };
 
-class DeleteParam : public SymbolicRosApiCall {
+class DeleteParam : public NamedSymbolicRosApiCall {
 public:
-  DeleteParam(std::unique_ptr<SymbolicString> name) : SymbolicRosApiCall(std::move(name)) {}
+  DeleteParam(std::unique_ptr<SymbolicString> name) : NamedSymbolicRosApiCall(std::move(name)) {}
 
   void print(llvm::raw_ostream &os) const override {
     os << "(deletes-param ";
@@ -245,11 +250,11 @@ public:
 };
 
 class HasParam :
-  public SymbolicRosApiCall,
+  public NamedSymbolicRosApiCall,
   public virtual SymbolicBool
 {
 public:
-  HasParam(std::unique_ptr<SymbolicString> name) : SymbolicRosApiCall(std::move(name)) {}
+  HasParam(std::unique_ptr<SymbolicString> name) : NamedSymbolicRosApiCall(std::move(name)) {}
 
   void print(llvm::raw_ostream &os) const override {
     os << "(checks-for-param ";
@@ -266,14 +271,14 @@ public:
 };
 
 class ReadParamWithDefault :
-  public SymbolicRosApiCall,
+  public NamedSymbolicRosApiCall,
   public virtual SymbolicValue
 {
 public:
   ReadParamWithDefault(
     std::unique_ptr<SymbolicString> name,
     std::unique_ptr<SymbolicValue> defaultValue
-  ) : SymbolicRosApiCall(std::move(name)), defaultValue(std::move(defaultValue))
+  ) : NamedSymbolicRosApiCall(std::move(name)), defaultValue(std::move(defaultValue))
   {}
 
   SymbolicValue const * getDefaultValue() const {

--- a/include/rosdiscover-clang/BackwardSymbolizer/FunctionSymbolizer.h
+++ b/include/rosdiscover-clang/BackwardSymbolizer/FunctionSymbolizer.h
@@ -381,13 +381,13 @@ private:
     }
   }
 
-  std::unique_ptr<SymbolicString> symbolizeApiCallName(api_call::RosApiCall *apiCall) {
+  std::unique_ptr<SymbolicString> symbolizeApiCallName(api_call::NamedRosApiCall *apiCall) {
     return stringSymbolizer.symbolize(const_cast<clang::Expr*>(apiCall->getNameExpr()));
   }
 
   std::unique_ptr<SymbolicString> symbolizeNodeHandleApiCallName(
     std::unique_ptr<SymbolicNodeHandle> nodeHandle,
-    api_call::RosApiCall *apiCall
+    api_call::NamedRosApiCall *apiCall
   ) {
     auto name = symbolizeApiCallName(apiCall);
 
@@ -592,7 +592,6 @@ private:
   ) {
     llvm::outs() << "DEBUG: symbolizing RateSleepCall\n";
     return std::make_unique<RateSleep>(
-        symbolizeApiCallName(apiCall),
         floatSymbolizer.symbolize(apiCall->getRate(astContext))
     );    
   }
@@ -601,7 +600,7 @@ private:
     api_call::PublishCall *apiCall
   ) {
     llvm::outs() << "DEBUG: symbolizing SubscribeTopicCall\n";
-    return std::make_unique<Publish>(symbolizeApiCallName(apiCall), 
+    return std::make_unique<Publish>(
         apiCall->getPublisherName()
     );
   }


### PR DESCRIPTION
This PR introduces NamedRosApiCall and NamedSymbolicRosApiCall to not assume that any API call has a name expression