### PR TITLE
Add controlflow

### DIFF
--- a/include/rosdiscover-clang/ApiCall/Calls/Util.h
+++ b/include/rosdiscover-clang/ApiCall/Calls/Util.h
@@ -8,6 +8,18 @@
 #include "../RosApiCall.h"
 
 namespace rosdiscover {
+
+  static inline bool stmtContainsStmt(const clang::Stmt* parent, const clang::Stmt* child) {
+    for (auto c: parent->children()) {
+      if (c == child) {
+        return true;
+      } else if (stmtContainsStmt(c, child)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
 namespace api_call {
 
   static clang::APValue const * evaluateNumber(

--- a/include/rosdiscover-clang/ApiCall/Calls/Util.h
+++ b/include/rosdiscover-clang/ApiCall/Calls/Util.h
@@ -10,7 +10,6 @@
 namespace rosdiscover {
 
   static inline bool stmtContainsStmt(const clang::Stmt* parent, const clang::Stmt* child) {
-    int i = 0;
     if (parent == nullptr || child == nullptr) {
       return false;
     }

--- a/include/rosdiscover-clang/ApiCall/Calls/Util.h
+++ b/include/rosdiscover-clang/ApiCall/Calls/Util.h
@@ -10,6 +10,10 @@
 namespace rosdiscover {
 
   static inline bool stmtContainsStmt(const clang::Stmt* parent, const clang::Stmt* child) {
+    int i = 0;
+    if (parent == nullptr || child == nullptr) {
+      return false;
+    }
     for (auto c: parent->children()) {
       if (c == child) {
         return true;

--- a/include/rosdiscover-clang/Ast/Stmt/Compound.h
+++ b/include/rosdiscover-clang/Ast/Stmt/Compound.h
@@ -6,7 +6,7 @@
 
 namespace rosdiscover {
 
-class SymbolicCompound {
+class SymbolicCompound : public SymbolicStmt {
 public:
   SymbolicCompound() : statements() {}
   ~SymbolicCompound(){}

--- a/include/rosdiscover-clang/Ast/Stmt/If.h
+++ b/include/rosdiscover-clang/Ast/Stmt/If.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <string>
+
+#include "../../Value/Value.h"
+#include "../Decl/LocalVariable.h"
+#include "Stmt.h"
+#include "Compound.h"
+
+namespace rosdiscover {
+
+class SymbolicIfStmt : public SymbolicStmt {
+public:
+  SymbolicIfStmt(
+    clang::Stmt* stmt,
+    std::unique_ptr<SymbolicBool> condition,
+    std::unique_ptr<SymbolicCompound> trueBranchBody,
+    std::unique_ptr<SymbolicCompound> falseBranchBody
+  ) : stmt(stmt), condition(std::move(condition)), trueBranchBody(std::move(trueBranchBody)), falseBranchBody(std::move(falseBranchBody))
+  {}
+  ~SymbolicIfStmt(){}
+
+  void print(llvm::raw_ostream &os) const override {
+    os << "(if ";
+    condition->print(os);
+    os << " ";
+    trueBranchBody->print(os);
+    os << " else ";
+    falseBranchBody->print(os);
+    os << ")";
+  }
+
+  nlohmann::json toJson() const override {
+    return {
+      {"kind", "if"},
+      {"condition", condition->toJson()},
+      {"trueBranchBody" ,  trueBranchBody->toJson()},
+      {"falseBranchBody", falseBranchBody->toJson()}
+    };
+  }
+
+  clang::Stmt* getStmt() {
+    return stmt;
+  }
+
+private:
+  clang::Stmt* stmt;
+  std::unique_ptr<SymbolicBool> condition;
+  std::unique_ptr<SymbolicCompound> trueBranchBody;
+  std::unique_ptr<SymbolicCompound> falseBranchBody;
+};
+
+} // rosdiscover

--- a/include/rosdiscover-clang/Ast/Stmt/Stmts.h
+++ b/include/rosdiscover-clang/Ast/Stmt/Stmts.h
@@ -4,4 +4,6 @@
 #include "ApiCall.h"
 #include "Assignment.h"
 #include "Compound.h"
+#include "If.h"
+#include "While.h"
 #include "Stmt.h"

--- a/include/rosdiscover-clang/Ast/Stmt/While.h
+++ b/include/rosdiscover-clang/Ast/Stmt/While.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <string>
+
+#include "../../Value/Value.h"
+#include "../Decl/LocalVariable.h"
+#include "Stmt.h"
+#include "Compound.h"
+
+namespace rosdiscover {
+
+class SymbolicWhileStmt : public SymbolicStmt {
+public:
+  SymbolicWhileStmt(
+    clang::Stmt* stmt,
+    std::unique_ptr<SymbolicBool> condition,
+    std::unique_ptr<SymbolicCompound> body
+  ) : stmt(stmt), condition(std::move(condition)), body(std::move(body))
+  {}
+  ~SymbolicWhileStmt(){}
+
+  void print(llvm::raw_ostream &os) const override {
+    os << "(while ";
+    condition->print(os);
+    os << " ";
+    body->print(os);
+    os << ")";
+  }
+
+  nlohmann::json toJson() const override {
+    return {
+      {"kind", "while"},
+      {"condition", condition->toJson()},
+      {"body" ,  body->toJson()}
+    };
+  }
+
+  clang::Stmt* getStmt() {
+    return stmt;
+  }
+
+private:
+  clang::Stmt* stmt;
+  std::unique_ptr<SymbolicBool> condition;
+  std::unique_ptr<SymbolicCompound> body;
+};
+
+} // rosdiscover

--- a/include/rosdiscover-clang/BackwardSymbolizer/BoolSymbolizer.h
+++ b/include/rosdiscover-clang/BackwardSymbolizer/BoolSymbolizer.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <string>
+#include <unordered_map>
+
+#include <clang/AST/Expr.h>
+#include <clang/AST/ExprCXX.h>
+#include <llvm/ADT/APInt.h>
+
+#include "../Builder/ValueBuilder.h"
+#include "../Value/String.h"
+#include "../Helper/FindDefVisitor.h"
+
+namespace rosdiscover {
+
+class BoolSymbolizer {
+public:
+  BoolSymbolizer(
+    clang::ASTContext &astContext
+  )
+  : astContext(astContext), valueBuilder() {}
+
+  std::unique_ptr<SymbolicBool> symbolize(clang::Expr *expr) {
+    if (expr == nullptr) {
+      llvm::outs() << "ERROR! Symbolizing (bool): NULLPTR";
+      return valueBuilder.unknown();
+    }
+
+    expr = expr->IgnoreParenCasts()->IgnoreImpCasts()->IgnoreCasts();
+
+    llvm::outs() << "symbolizing (bool): ";
+    expr->dump();
+    llvm::outs() << "\n";
+
+    if (expr->isKnownToHaveBooleanValue()) {
+      bool result;
+      expr->EvaluateAsBooleanCondition(result, astContext);
+      valueBuilder.boolLiteral(result);
+    }
+
+    llvm::outs() << "unable to symbolize expression: treating as unknown\n";
+    return valueBuilder.unknown();
+  }
+
+private:
+  clang::ASTContext &astContext;
+  ValueBuilder valueBuilder;
+};
+
+} // rosdiscover

--- a/include/rosdiscover-clang/BackwardSymbolizer/BoolSymbolizer.h
+++ b/include/rosdiscover-clang/BackwardSymbolizer/BoolSymbolizer.h
@@ -38,7 +38,7 @@ public:
       valueBuilder.boolLiteral(result);
     }
 
-    llvm::outs() << "unable to symbolize expression: treating as unknown\n";
+    llvm::outs() << "unable to symbolize expression (bool): treating as unknown\n";
     return valueBuilder.unknown();
   }
 

--- a/include/rosdiscover-clang/BackwardSymbolizer/FunctionSymbolizer.h
+++ b/include/rosdiscover-clang/BackwardSymbolizer/FunctionSymbolizer.h
@@ -875,8 +875,8 @@ private:
       auto rawWhile = it.second;
       ordered.push_back(std::unique_ptr<RawStatement>(rawWhile));
       llvm::outs() << "while body: ";
-      for (auto compound: rawWhile->getBody()->getStmts()) {
-        compound->getUnderlyingStmt()->dump();
+      for (auto compoundStmt : rawWhile->getBody()->getStmts()) {
+        compoundStmt->getUnderlyingStmt()->dump();
         llvm::outs() << ",\n";
       }
       llvm::outs() << ".\n";

--- a/include/rosdiscover-clang/BackwardSymbolizer/FunctionSymbolizer.h
+++ b/include/rosdiscover-clang/BackwardSymbolizer/FunctionSymbolizer.h
@@ -864,14 +864,16 @@ private:
     }
  
     std::vector<RawStatement*> result;
-    for (auto &rawStmt : ordered) {
+    for (auto &rawStmt : ordered) { //In lexical order look for control flow parents and add them to result
       auto highestLevelParent = constructParentControlFlow(rawStmt);
+
+      //avoid duplication in the result
       if (std::find(result.begin(), result.end(), highestLevelParent) == result.end()) {
-        result.push_back(highestLevelParent);
+        result.push_back(highestLevelParent); 
       }
     }
-    llvm::outs() << "return result\n";
     
+    //For compatibiliy, include the leaves for now. TODO: Fix rosdisover python to find leaves in control flow.
     ordered.insert( ordered.end(), result.begin(), result.end() );
     return ordered;
   }
@@ -915,7 +917,6 @@ private:
     auto compound = std::make_unique<SymbolicCompound>();
 
     for (auto &rawStmt : computeStatementOrder()) {
-      llvm::outs() << "return computeStatementOrder\n";
       compound->append(symbolizeStatement(rawStmt));
     }
 

--- a/include/rosdiscover-clang/BackwardSymbolizer/FunctionSymbolizer.h
+++ b/include/rosdiscover-clang/BackwardSymbolizer/FunctionSymbolizer.h
@@ -780,29 +780,29 @@ private:
       raw = whileMap[whileID].get();
     }
 
-    clang::IfStmt const *ifStmt = node.get<clang::IfStmt>();
+    /*clang::IfStmt const *ifStmt = node.get<clang::IfStmt>();
     if (ifStmt != nullptr) {
       llvm::outs() << "DEBUG FOUND IF!!!!";
 
       long ifID = ifStmt->getID(astContext);
       if (!ifMap.count(ifID)) {
-        ifMap.emplace(whileID, std::unique_ptr<RawIfStatement>(new RawIfStatement(const_cast<clang::IfStmt*>(ifStmt))));
+        ifMap.emplace(ifID, std::unique_ptr<RawIfStatement>(new RawIfStatement(const_cast<clang::IfStmt*>(ifStmt))));
       }
 
       //Add to if or else branch
       if (stmtContainsStmt(ifStmt->getThen(), raw->getUnderlyingStmt())) { 
-        ifMap.at(ifID)->getTrue()->append(raw);
+        ifMap.at(ifID)->getTrueBody()->append(raw);
       } else if (stmtContainsStmt(ifStmt->getElse(), raw->getUnderlyingStmt())) { 
-        ifMap.at(ifID)->getFalse()->append(raw);
+        ifMap.at(ifID)->getFalseBody()->append(raw);
       } else {
         llvm::outs() << "ERROR: raw is neither in then nor else! Raw: ";
-        raw->getUnderlyingStmt().dump();
+        raw->getUnderlyingStmt()->dump();
         llvm::outs() << "\n IfStmt: ";
-        ifStmt.dump();
+        ifStmt->dump();
         llvm::outs() << "\n";
       }
       raw = ifMap[ifID].get();
-    }
+    }*/
 
     for (clang::DynTypedNode const parent : astContext.getParents(node)) {
       auto stmt = getParentStmt(parent, raw);
@@ -857,6 +857,22 @@ private:
     std::vector<std::unique_ptr<RawStatement>> result;
     for (auto &rawStmt : ordered) {
       result.push_back(std::unique_ptr<RawStatement>(getParentStmt(rawStmt.get())));
+    }
+    /*llvm::outs() << "DEBUG computeStatementOrder results for: ";
+    function->dump();
+    llvm::outs() << "\n";
+    for (auto &r : result) {
+      r->getUnderlyingStmt()->dump();
+      llvm::outs() << "\n";
+    }*/
+    for (auto &it: whileMap) {
+      auto rawWhile = it.second.get();
+      llvm::outs() << "while body: ";
+      for (auto compound: rawWhile->getBody()->getStmts()) {
+        compound->getUnderlyingStmt()->dump();
+        llvm::outs() << ",\n";
+      }
+      llvm::outs() << ".\n";
     }
 
     return ordered;

--- a/include/rosdiscover-clang/BackwardSymbolizer/FunctionSymbolizer.h
+++ b/include/rosdiscover-clang/BackwardSymbolizer/FunctionSymbolizer.h
@@ -854,10 +854,19 @@ private:
       }
     }
 
+
+    
     std::vector<std::unique_ptr<RawStatement>> result;
     for (auto &rawStmt : ordered) {
-      result.push_back(std::unique_ptr<RawStatement>(getParentStmt(rawStmt.get())));
+      auto r = getParentStmt(rawStmt.get());
+      if (r ==  nullptr) {
+        llvm::outs() << "ERROR. Could not find parent.\n";
+        continue;
+      }
+      result.push_back(std::unique_ptr<RawStatement>());
     }
+    
+
     /*llvm::outs() << "DEBUG computeStatementOrder results for: ";
     function->dump();
     llvm::outs() << "\n";
@@ -865,6 +874,8 @@ private:
       r->getUnderlyingStmt()->dump();
       llvm::outs() << "\n";
     }*/
+
+    /*
     for (auto &it: whileMap) {
       auto rawWhile = it.second.get();
       llvm::outs() << "while body: ";
@@ -873,7 +884,7 @@ private:
         llvm::outs() << ",\n";
       }
       llvm::outs() << ".\n";
-    }
+    }*/
 
     return ordered;
   }

--- a/include/rosdiscover-clang/BackwardSymbolizer/FunctionSymbolizer.h
+++ b/include/rosdiscover-clang/BackwardSymbolizer/FunctionSymbolizer.h
@@ -803,9 +803,15 @@ private:
 
       //Add to if or else branch
       if (ifStmt->getThen() == raw->getUnderlyingStmt() || stmtContainsStmt(ifStmt->getThen(), raw->getUnderlyingStmt())) { 
+        llvm::outs() << "Debug: Add to then";
         ifMap.at(ifID)->getTrueBody()->append(raw);
+        raw = ifMap[ifID];
       } else if (ifStmt->getElse() == raw->getUnderlyingStmt() || stmtContainsStmt(ifStmt->getElse(), raw->getUnderlyingStmt())) { 
+        llvm::outs() << "Debug: Add to else";
         ifMap.at(ifID)->getFalseBody()->append(raw);
+        raw = ifMap[ifID];
+      } else if (ifStmt->getCond() == raw->getUnderlyingStmt() || stmtContainsStmt(ifStmt->getCond(), raw->getUnderlyingStmt())) { 
+        llvm::outs() << "Debug: In condition, treat as outside of if";
       } else {
         llvm::outs() << "ERROR: raw is neither in then nor else! Raw: ";
         raw->getUnderlyingStmt()->dump();

--- a/include/rosdiscover-clang/BackwardSymbolizer/FunctionSymbolizer.h
+++ b/include/rosdiscover-clang/BackwardSymbolizer/FunctionSymbolizer.h
@@ -870,15 +870,6 @@ private:
       result.push_back(std::unique_ptr<RawStatement>());
     }
     
-
-    /*llvm::outs() << "DEBUG computeStatementOrder results for: ";
-    function->dump();
-    llvm::outs() << "\n";
-    for (auto &r : result) {
-      r->getUnderlyingStmt()->dump();
-      llvm::outs() << "\n";
-    }*/
-
     for (auto &it: whileMap) {
       auto rawWhile = it.second;
       ordered.push_back(std::unique_ptr<RawStatement>(rawWhile));

--- a/include/rosdiscover-clang/BackwardSymbolizer/FunctionSymbolizer.h
+++ b/include/rosdiscover-clang/BackwardSymbolizer/FunctionSymbolizer.h
@@ -734,7 +734,14 @@ private:
 
     return std::make_unique<SymbolicIfStmt>(stmt, std::move(value), std::move(trueBranch), std::move(falseBranch));
   }
+  std::unique_ptr<SymbolicCompound> symbolizeCompound(RawCompound *stmt) {
+    auto result = std::make_unique<SymbolicCompound>();
+    for (auto &s: stmt->getStmts()) {
+      result->append(symbolizeStatement(s.get()));
+    }
 
+    return result;
+  }
   std::unique_ptr<SymbolicWhileStmt> symbolizeWhile(clang::WhileStmt *stmt) {
     llvm::outs() << "DEBUG: symbolizing while: ";
     stmt->dump();
@@ -805,6 +812,9 @@ private:
         break;
       case RawStatementKind::While:
         symbolic = symbolizeWhile(((RawWhileStatement*) statement)->getWhileStmt());
+        break;
+      case RawStatementKind::Compound:
+        symbolic = symbolizeCompound((RawCompound*) statement);
         break;
     }
     return AnnotatedSymbolicStmt::create(

--- a/include/rosdiscover-clang/BackwardSymbolizer/FunctionSymbolizer.h
+++ b/include/rosdiscover-clang/BackwardSymbolizer/FunctionSymbolizer.h
@@ -741,6 +741,7 @@ private:
 
     return std::make_unique<SymbolicIfStmt>(stmt, std::move(value), std::move(trueBranch), std::move(falseBranch));
   }
+
   std::unique_ptr<SymbolicCompound> symbolizeCompound(RawCompound *stmt) {
     auto result = std::make_unique<SymbolicCompound>();
     for (auto &s: stmt->getStmts()) {
@@ -749,6 +750,7 @@ private:
 
     return result;
   }
+
   std::unique_ptr<SymbolicWhileStmt> symbolizeWhile(RawWhileStatement* rawWhile) {
 
     clang::WhileStmt *stmt = rawWhile->getWhileStmt();
@@ -822,7 +824,6 @@ private:
     auto node = clang::DynTypedNode::create(*(raw->getUnderlyingStmt()));
     return getParentStmt(node, raw);
   }
-
 
   std::vector<std::unique_ptr<RawStatement>> computeStatementOrder() {
     // unify all of the statements in this function

--- a/include/rosdiscover-clang/BackwardSymbolizer/FunctionSymbolizer.h
+++ b/include/rosdiscover-clang/BackwardSymbolizer/FunctionSymbolizer.h
@@ -772,8 +772,7 @@ private:
       long whileID = whileStmt->getID(astContext);
       if (!whileMap.count(whileID)) {
         std::unique_ptr<RawWhileStatement> rs = std::unique_ptr<RawWhileStatement>(new RawWhileStatement(const_cast<clang::WhileStmt*>(whileStmt)));
-        //auto pair = std::make_pair<long, std::unique_ptr<RawWhileStatement>>(whileID, std::move(rs));
-        //whileMap.insert(pair);
+        whileMap.emplace(whileID, std::move(rs));
 
       }
 

--- a/include/rosdiscover-clang/BackwardSymbolizer/FunctionSymbolizer.h
+++ b/include/rosdiscover-clang/BackwardSymbolizer/FunctionSymbolizer.h
@@ -105,9 +105,9 @@ private:
   IntSymbolizer intSymbolizer;
   FloatSymbolizer floatSymbolizer;
   BoolSymbolizer boolSymbolizer;
-  std::unordered_map<long, RawIfStatement*> ifMap;
-  std::unordered_map<long, RawWhileStatement*> whileMap;
-  std::unordered_map<long, RawCompound*> compoundMap;
+  std::unordered_map<long, RawIfStatement*> ifMap; //keys are the IDs of the corresponding clang stmts.
+  std::unordered_map<long, RawWhileStatement*> whileMap; //keys are the IDs of the corresponding clang stmts.
+  std::unordered_map<long, RawCompound*> compoundMap; //keys are the IDs of the corresponding clang stmts.
   ValueBuilder valueBuilder;
   std::unordered_set<std::string> symbolicArgNames;
   [[maybe_unused]] std::vector<Callback*> &callbacks;

--- a/include/rosdiscover-clang/RawStatement.h
+++ b/include/rosdiscover-clang/RawStatement.h
@@ -3,6 +3,8 @@
 #include <clang/AST/Stmt.h>
 
 #include "ApiCall/RosApiCall.h"
+#include "Ast/Stmt/If.h"
+#include "Ast/Stmt/While.h"
 #include "Callback/Callback.h"
 
 namespace rosdiscover {
@@ -10,7 +12,9 @@ namespace rosdiscover {
 enum class RawStatementKind {
   RosApiCall,
   FunctionCall,
-  Callback
+  Callback,
+  If,
+  While
 };
 
 class RawStatement {
@@ -18,6 +22,48 @@ public:
   virtual ~RawStatement(){}
   virtual clang::Stmt* getUnderlyingStmt() = 0;
   virtual RawStatementKind getKind() = 0;
+};
+
+class RawIfStatement : public RawStatement {
+public:
+  RawIfStatement(clang::IfStmt *ifStmt) : ifStmt(ifStmt) {}
+  ~RawIfStatement(){}
+
+  clang::Stmt* getUnderlyingStmt() override {
+    return ifStmt;
+  }
+
+  clang::IfStmt* getIfStmt() {
+    return ifStmt;
+  }
+
+  RawStatementKind getKind() override {
+    return RawStatementKind::If;
+  }
+
+private:
+  clang::IfStmt *ifStmt;
+};
+
+class RawWhileStatement : public RawStatement {
+public:
+  RawWhileStatement(clang::WhileStmt *whileStmt) : whileStmt(whileStmt) {}
+  ~RawWhileStatement(){}
+
+  clang::Stmt* getUnderlyingStmt() override {
+    return whileStmt;
+  }
+
+  clang::WhileStmt* getWhileStmt() {
+    return whileStmt;
+  }
+  
+  RawStatementKind getKind() override {
+    return RawStatementKind::While;
+  }
+
+private:
+  clang::WhileStmt *whileStmt;
 };
 
 class RawRosApiCallStatement : public RawStatement {

--- a/include/rosdiscover-clang/RawStatement.h
+++ b/include/rosdiscover-clang/RawStatement.h
@@ -31,19 +31,19 @@ public:
   ~RawCompound(){}
 
   RawCompound(RawCompound&& other)
-  : underlyingStmt(other.underlyingStmt), statements(std::move(other.statements))
+  : underlyingStmt(other.underlyingStmt), statements(other.statements)
   {}
 
-  void append(std::unique_ptr<RawStatement> statement) {
-    statements.push_back(std::move(statement));
+  void append(RawStatement* statement) {
+    statements.push_back(statement);
   }
 
   clang::Stmt* getUnderlyingStmt() override {
     return underlyingStmt;
   }
 
-  std::vector<std::unique_ptr<RawStatement>> getStmts() {
-    return std::move(statements);
+  std::vector<RawStatement*> getStmts() {
+    return statements;
   }
 
   RawStatementKind getKind() override {
@@ -52,7 +52,10 @@ public:
 
 private:
   clang::Stmt* underlyingStmt; 
-  std::vector<std::unique_ptr<RawStatement>> statements;
+  std::vector<RawStatement*> statements;
+
+  //Todo destruct statements in destructor
+
 }; //RawCompound
 
 class RawIfStatement : public RawStatement {

--- a/include/rosdiscover-clang/RawStatement.h
+++ b/include/rosdiscover-clang/RawStatement.h
@@ -54,8 +54,6 @@ private:
   clang::Stmt* underlyingStmt; 
   std::vector<RawStatement*> statements;
 
-  //Todo destruct statements in destructor
-
 }; //RawCompound
 
 class RawIfStatement : public RawStatement {

--- a/include/rosdiscover-clang/RawStatement.h
+++ b/include/rosdiscover-clang/RawStatement.h
@@ -25,7 +25,7 @@ public:
   virtual RawStatementKind getKind() = 0;
 };
 
-class RawCompound: public RawStatement {
+class RawCompound : public RawStatement {
 public:
   RawCompound(clang::Stmt* underlyingStmt) : underlyingStmt(underlyingStmt), statements() {}
   ~RawCompound(){}


### PR DESCRIPTION
This adds if and while to rosdiscover. The format looks like this:

```
            {
              "body": {
                "kind": "compound",
                "statements": [
                  {
                    "condition": {
                      "kind": "unknown"
                    },
                    "falseBranchBody": {
                      "kind": "compound",
                      "statements": []
                    },
                    "kind": "if",
                    "source-location": "</home/autoware/Autoware/ros/src/computing/planning/motion/packages/waypoint_follower/nodes/wf_simulator/wf_simulator.cpp:305:5, line:309:5>",
                    "trueBranchBody": {
                      "kind": "compound",
                      "statements": [
                        {
                          "kind": "ratesleep",
                          "rate": {
                            "kind": "float-literal",
                            "literal": 50.0
                          },
                          "source-location": "</home/autoware/Autoware/ros/src/computing/planning/motion/packages/waypoint_follower/nodes/wf_simulator/wf_simulator.cpp:307:7, col:23>"
                        }
                      ]
                    }
                  },
                  {
                    "arguments": {},
                    "callee": "(anonymous namespace)::publishOdometry",
                    "kind": "call",
                    "source-location": "</home/autoware/Autoware/ros/src/computing/planning/motion/packages/waypoint_follower/nodes/wf_simulator/wf_simulator.cpp:312:5, col:21>"
                  },
                  {
                    "kind": "ratesleep",
                    "rate": {
                      "kind": "float-literal",
                      "literal": 50.0
                    },
                    "source-location": "</home/autoware/Autoware/ros/src/computing/planning/motion/packages/waypoint_follower/nodes/wf_simulator/wf_simulator.cpp:314:5, col:21>"
                  }
                ]
              },
              "condition": {
                "kind": "unknown"
              },
              "kind": "while",
              "source-location": "</home/autoware/Autoware/ros/src/computing/planning/motion/packages/waypoint_follower/nodes/wf_simulator/wf_simulator.cpp:301:3, line:315:3>"
            }
          ]
        },
```

Right now it just adds all the control flow to the output, which means the output is redundant. I'll fix this in a subsequent PR since this requires a non-trivial refactoring of rosdiscover. 