### PR TITLE
Negate conditions based on the types of edges in the Control Dependence Graph

### DIFF
--- a/include/rosdiscover-clang/Ast/Stmt/ControlDependency.h
+++ b/include/rosdiscover-clang/Ast/Stmt/ControlDependency.h
@@ -15,16 +15,22 @@ public:
   SymbolicControlDependency(
     std::vector<std::unique_ptr<SymbolicCall>> functionCalls,
     std::vector<std::unique_ptr<SymbolicVariableReference>> variableReferences, 
+    bool negate,
     std::string const location,
     std::string const condition=""
   ) : functionCalls(std::move(functionCalls)), 
       variableReferences(std::move(variableReferences)), 
+      negate(negate),
       location(location), 
       condition(condition) {}
   ~SymbolicControlDependency(){}
 
   void print(llvm::raw_ostream &os) const override {
     os << "(controlDependency)";
+  }
+
+  bool isNegated() const {
+    return negate;
   }
 
   nlohmann::json toJson() const override {
@@ -40,6 +46,7 @@ public:
       {"kind", "controlDependency"},
       {"calls", jCalls},
       {"variableReferences", jVarrefs},
+      {"negate", negate},
       {"source-location", location},
       {"condition", condition},
     };
@@ -48,6 +55,7 @@ public:
 private:
   std::vector<std::unique_ptr<SymbolicCall>> functionCalls;
   std::vector<std::unique_ptr<SymbolicVariableReference>> variableReferences;
+  bool negate;
   std::string const location;
   std::string const condition;
 };

--- a/include/rosdiscover-clang/BackwardSymbolizer/FunctionSymbolizer.h
+++ b/include/rosdiscover-clang/BackwardSymbolizer/FunctionSymbolizer.h
@@ -10,7 +10,6 @@
 #include <clang/Analysis/CFG.h>
 #include <clang/Analysis/Analyses/Dominators.h>
 #include <clang/Analysis/CFGStmtMap.h>
-#include <clang/Analysis/Analyses/CFGReachabilityAnalysis.h>
 #include <clang/AST/ParentMap.h>
 #include <llvm/ADT/BitVector.h>
 #include <llvm/ADT/SmallVector.h>
@@ -703,7 +702,6 @@ private:
     auto deps = cdc.getControlDependencies(const_cast<clang::CFGBlock *>(stmt_block));
     //sourceCFG->dump(clang::LangOptions(), true);
     llvm::outs() << "succs:\n";
-    clang::CFGReverseBlockReachabilityAnalysis reachabilityAnalysis = clang::CFGReverseBlockReachabilityAnalysis(*(sourceCFG.get()));
     
     std::vector<std::unique_ptr<SymbolicControlDependency>> results;
 

--- a/include/rosdiscover-clang/BackwardSymbolizer/FunctionSymbolizer.h
+++ b/include/rosdiscover-clang/BackwardSymbolizer/FunctionSymbolizer.h
@@ -698,7 +698,6 @@ private:
     auto stmt_block = CM->getBlock(stmt); 
     stmt_block->dump();
     auto deps = cdc.getControlDependencies(const_cast<clang::CFGBlock *>(stmt_block));
-    //sourceCFG->dump(clang::LangOptions(), true);
     llvm::outs() << "succs:\n";
     
     std::vector<std::unique_ptr<SymbolicControlDependency>> results;

--- a/include/rosdiscover-clang/BackwardSymbolizer/FunctionSymbolizer.h
+++ b/include/rosdiscover-clang/BackwardSymbolizer/FunctionSymbolizer.h
@@ -11,8 +11,6 @@
 #include <clang/Analysis/Analyses/Dominators.h>
 #include <clang/Analysis/CFGStmtMap.h>
 #include <clang/AST/ParentMap.h>
-#include <llvm/ADT/BitVector.h>
-#include <llvm/ADT/SmallVector.h>
 
 #include <fmt/core.h>
 
@@ -717,7 +715,7 @@ private:
         if (block == nullptr || block->empty() || block->size() < 1 || block->size() > 1000 || block->getTerminatorStmt() == nullptr )   {
           continue;
         }
-        llvm::outs() << "size " << block->size() << "\n";                
+        llvm::outs() << "size " << block->size() << "\n";
         llvm::outs() << "looking for terminator condition in " << block->getTerminatorStmt()->getStmtClassName() << "\n";
 
         const auto *condition = block->getTerminatorCondition();

--- a/include/rosdiscover-clang/BackwardSymbolizer/FunctionSymbolizer.h
+++ b/include/rosdiscover-clang/BackwardSymbolizer/FunctionSymbolizer.h
@@ -753,13 +753,22 @@ private:
               llvm::outs() << "false branch dominates stmt\n";
               falseBranchDominates = true;
             }
-          }//TODO: Check whether this works for switch-case as well
+          } else {
+            //TODO: Handle switch-case here
+            llvm::outs() << "Too many branches. Swich not yet supported\n";
+            abort();
+          }
           llvm::outs() << i++;
           sBlock->dump();
         }
         if ((trueBranchDominates && falseBranchDominates) || (!trueBranchDominates && !falseBranchDominates)){
-          llvm::outs() << "ERROR: falseBranchDominates: " << falseBranchDominates << " trueBranchDominates: " << trueBranchDominates << " block: ";
+          llvm::outs() << "ERROR: falseBranchDominates: " << falseBranchDominates << " trueBranchDominates: " << trueBranchDominates << "\n";
+          llvm::outs() << "prevBlock: ";
+          prevBlock->dump();
+          llvm::outs() << "\nblock: ";
           block->dump();
+          llvm::outs() << "\nCFG: ";
+          sourceCFG->dump(clang::LangOptions(), false);
           abort();
         }
 

--- a/include/rosdiscover-clang/BackwardSymbolizer/FunctionSymbolizer.h
+++ b/include/rosdiscover-clang/BackwardSymbolizer/FunctionSymbolizer.h
@@ -751,7 +751,7 @@ private:
               llvm::outs() << "false branch dominates stmt\n";
               falseBranchDominates = true;
             }
-          }          
+          }//TODO: Check whether this works for switch-case as well
           llvm::outs() << i++;
           sBlock->dump();
         }

--- a/include/rosdiscover-clang/BackwardSymbolizer/FunctionSymbolizer.h
+++ b/include/rosdiscover-clang/BackwardSymbolizer/FunctionSymbolizer.h
@@ -735,6 +735,16 @@ private:
     auto CM = std::unique_ptr<clang::CFGStmtMap>(clang::CFGStmtMap::Build(sourceCFG.get(), PM.get()));
     auto stmt_block = CM->getBlock(stmt); 
     auto deps = cdc.getControlDependencies(const_cast<clang::CFGBlock *>(stmt_block));
+    sourceCFG->dump(clang::LangOptions(), true);
+    llvm::outs() << "succs:\n";
+    for (clang::CFGBlock *block: deps) {
+      int i = 0;
+      for (clang::CFGBlock *sBlock: block->succs()) {
+        llvm::outs() << i++;
+        sBlock->dump();
+      }
+    }
+    abort();
     llvm::outs() << "getControlDependencies end\n";
     return deps;
   }

--- a/include/rosdiscover-clang/BackwardSymbolizer/FunctionSymbolizer.h
+++ b/include/rosdiscover-clang/BackwardSymbolizer/FunctionSymbolizer.h
@@ -710,10 +710,10 @@ private:
     auto prevBlock = stmt_block;
 
     for (clang::CFGBlock *block: deps) {
-      auto entry = sourceCFG.get()->createBlock();
+      auto entry = sourceCFG->createBlock();
       clang::CFGBlock::AdjacentBlock aBlock(block, true);
-      entry->addSuccessor(aBlock, sourceCFG.get()->getBumpVectorContext());
-      sourceCFG.get()->setEntry(entry);
+      entry->addSuccessor(aBlock, sourceCFG->getBumpVectorContext());
+      sourceCFG->setEntry(entry);
       clang::CFGDominatorTreeImpl<false> dominatorAnalysis(sourceCFG.get());
       try {
         if (block == nullptr || block->empty() || block->size() < 1 || block->size() > 1000 || block->getTerminatorStmt() == nullptr )   {

--- a/include/rosdiscover-clang/BackwardSymbolizer/FunctionSymbolizer.h
+++ b/include/rosdiscover-clang/BackwardSymbolizer/FunctionSymbolizer.h
@@ -732,6 +732,8 @@ private:
         auto conditionStr = rosdiscover::prettyPrint(condition, astContext);
         if (block->getTerminatorStmt()->getStmtClass() == clang::Stmt::SwitchStmtClass) {
           conditionStr = "switch (" + conditionStr + ")";
+          llvm::outs() << "ERROR: Encountered switch: " << conditionStr << "\n";
+          abort();
         }
         
         llvm::outs() << "terminator condition found: " << conditionStr << "\n";


### PR DESCRIPTION
This PR adds code that identifies whether a condition of a control-dependency needs to be negated due to a false branch being taken.