### PR TITLE
Reconstruct Control Dependency Graph

### DIFF
--- a/include/rosdiscover-clang/Ast/Stmt/ControlDependency.h
+++ b/include/rosdiscover-clang/Ast/Stmt/ControlDependency.h
@@ -15,22 +15,16 @@ public:
   SymbolicControlDependency(
     std::vector<std::unique_ptr<SymbolicCall>> functionCalls,
     std::vector<std::unique_ptr<SymbolicVariableReference>> variableReferences, 
-    bool negate,
     std::string const location,
     std::string const condition=""
   ) : functionCalls(std::move(functionCalls)), 
       variableReferences(std::move(variableReferences)), 
-      negate(negate),
       location(location), 
       condition(condition) {}
   ~SymbolicControlDependency(){}
 
   void print(llvm::raw_ostream &os) const override {
     os << "(controlDependency)";
-  }
-
-  bool isNegated() const {
-    return negate;
   }
 
   nlohmann::json toJson() const override {
@@ -46,7 +40,6 @@ public:
       {"kind", "controlDependency"},
       {"calls", jCalls},
       {"variableReferences", jVarrefs},
-      {"negate", negate},
       {"source-location", location},
       {"condition", condition},
     };
@@ -55,7 +48,6 @@ public:
 private:
   std::vector<std::unique_ptr<SymbolicCall>> functionCalls;
   std::vector<std::unique_ptr<SymbolicVariableReference>> variableReferences;
-  bool negate;
   std::string const location;
   std::string const condition;
 };

--- a/include/rosdiscover-clang/BackwardSymbolizer/FunctionSymbolizer.h
+++ b/include/rosdiscover-clang/BackwardSymbolizer/FunctionSymbolizer.h
@@ -798,23 +798,23 @@ private:
     }
   }
 
-  CFGBlock* buildGraph(const clang::CFGBlock* blockOfInterest, const llvm::SmallVector<clang::CFGBlock *, 4> &deps, clang::CFGDominatorTreeImpl<true> &postdominatorAnalysis, clang::CFGDominatorTreeImpl<false> &dominatorAnalysis) {
+  CFGBlock* buildGraph(const clang::CFGBlock* clangBlockOfInterest, const llvm::SmallVector<clang::CFGBlock *, 4> &deps, clang::CFGDominatorTreeImpl<true> &postdominatorAnalysis, clang::CFGDominatorTreeImpl<false> &dominatorAnalysis) {
     std::vector<const clang::CFGBlock*> analyzed;
     std::unordered_map<long, CFGBlock*> blockMap; //maps BlockID to CFGBlockObject
-    auto cfgBlockOfInterest = new CFGBlock(blockOfInterest);
-    blockMap.emplace(blockOfInterest->getBlockID(), cfgBlockOfInterest);
+    auto cfgBlockOfInterest = new CFGBlock(clangBlockOfInterest);
+    blockMap.emplace(clangBlockOfInterest->getBlockID(), cfgBlockOfInterest);
     std::vector<CFGBlock*> controlDependencyGraphNodes = {cfgBlockOfInterest};
     for (auto depsBlock: deps) {
-      if (postdominatorAnalysis.dominates(depsBlock, blockOfInterest) && !dominatorAnalysis.dominates(depsBlock, blockOfInterest))
+      if (postdominatorAnalysis.dominates(depsBlock, clangBlockOfInterest) && !dominatorAnalysis.dominates(depsBlock, clangBlockOfInterest))
         continue; //ignore CFG blocks that come after the block of interest.
       auto depsCfgBlock = new CFGBlock(depsBlock);
       blockMap.emplace(depsBlock->getBlockID(), depsCfgBlock);
       controlDependencyGraphNodes.push_back(depsCfgBlock);
     }
     llvm::outs() << "#### buildGraph ####\n";
-    buildGraph(true, blockOfInterest, deps, postdominatorAnalysis, dominatorAnalysis, analyzed, controlDependencyGraphNodes, blockMap);
+    buildGraph(true, clangBlockOfInterest, deps, postdominatorAnalysis, dominatorAnalysis, analyzed, controlDependencyGraphNodes, blockMap);
     llvm::outs() << "#### graph built ####\n";
-    return blockMap.at(blockOfInterest->getBlockID());
+    return blockMap.at(clangBlockOfInterest->getBlockID());
   }
 
   std::vector<std::unique_ptr<SymbolicControlDependency>> getControlDependenciesObjects(const clang::Stmt* stmt) {

--- a/include/rosdiscover-clang/BackwardSymbolizer/FunctionSymbolizer.h
+++ b/include/rosdiscover-clang/BackwardSymbolizer/FunctionSymbolizer.h
@@ -780,23 +780,23 @@ private:
     }
   }
 
-  CFGBlock* buildGraph(const clang::CFGBlock* block, const llvm::SmallVector<clang::CFGBlock *, 4> &deps, clang::CFGDominatorTreeImpl<true> &postdominatorAnalysis, clang::CFGDominatorTreeImpl<false> &dominatorAnalysis) {
+  CFGBlock* buildGraph(const clang::CFGBlock* blockOfInterest, const llvm::SmallVector<clang::CFGBlock *, 4> &deps, clang::CFGDominatorTreeImpl<true> &postdominatorAnalysis, clang::CFGDominatorTreeImpl<false> &dominatorAnalysis) {
     std::vector<const clang::CFGBlock*> analyzed;
     std::unordered_map<long, CFGBlock*> blockMap; //maps BlockID to CFGBlockObject
-    auto cfgBlock = new CFGBlock(block);
-    blockMap.emplace(block->getBlockID(), cfgBlock);
+    auto cfgBlock = new CFGBlock(blockOfInterest);
+    blockMap.emplace(blockOfInterest->getBlockID(), cfgBlock);
     std::vector<CFGBlock*> controlDependencyGraphNodes = {cfgBlock};
     for (auto depsBlock: deps) {
-      if (postdominatorAnalysis.dominates(depsBlock, block) && !dominatorAnalysis.dominates(depsBlock, block))
-        continue;
+      if (postdominatorAnalysis.dominates(depsBlock, blockOfInterest) && !dominatorAnalysis.dominates(depsBlock, blockOfInterest))
+        continue; //ignore CFG blocks that come after the block of interest.
       auto depsCfgBlock = new CFGBlock(depsBlock);
       blockMap.emplace(depsBlock->getBlockID(), depsCfgBlock);
       controlDependencyGraphNodes.push_back(depsCfgBlock);
     }
     llvm::outs() << "#### buildGraph ####\n";
-    buildGraph(true, block, deps, postdominatorAnalysis, dominatorAnalysis, analyzed, controlDependencyGraphNodes, blockMap);
+    buildGraph(true, blockOfInterest, deps, postdominatorAnalysis, dominatorAnalysis, analyzed, controlDependencyGraphNodes, blockMap);
     llvm::outs() << "#### graph built ####\n";
-    return blockMap.at(block->getBlockID());
+    return blockMap.at(blockOfInterest->getBlockID());
   }
 
   std::vector<std::unique_ptr<SymbolicControlDependency>> getControlDependenciesObjects(const clang::Stmt* stmt) {

--- a/include/rosdiscover-clang/BackwardSymbolizer/FunctionSymbolizer.h
+++ b/include/rosdiscover-clang/BackwardSymbolizer/FunctionSymbolizer.h
@@ -731,6 +731,7 @@ private:
           for (const clang::CFGBlock *sBlock: predecessor->getClangBlock()->succs()) {
             if (i == 0) { //true branch, as defined by clang's order of successors
             //TODO: Ensure that no blocks are skipped
+              //the only post-dominating control dependency is the directly following control dependency
               if (dominatorAnalysis.dominates(depBlock->getClangBlock(), sBlock) || depBlock->getClangBlock()->getBlockID() == sBlock->getBlockID()) {
                 llvm::outs() << "true branch dominates stmt\n";
                 trueBranchDominates = true;

--- a/include/rosdiscover-clang/BackwardSymbolizer/FunctionSymbolizer.h
+++ b/include/rosdiscover-clang/BackwardSymbolizer/FunctionSymbolizer.h
@@ -798,7 +798,12 @@ private:
     }
   }
 
-  std::unique_ptr<CFGBlock> buildGraph(const clang::CFGBlock* clangBlockOfInterest, const llvm::SmallVector<clang::CFGBlock *, 4> &deps, clang::CFGDominatorTreeImpl<true> &postdominatorAnalysis, clang::CFGDominatorTreeImpl<false> &dominatorAnalysis) {
+  std::unique_ptr<CFGBlock> buildGraph(
+      const clang::CFGBlock* clangBlockOfInterest,
+      const llvm::SmallVector<clang::CFGBlock *, 4> &deps,
+      clang::CFGDominatorTreeImpl<true> &postdominatorAnalysis,
+      clang::CFGDominatorTreeImpl<false> &dominatorAnalysis
+    ) {
     std::vector<const clang::CFGBlock*> analyzed;
     std::unordered_map<long, std::unique_ptr<CFGBlock>> blockMap; //maps BlockID to CFGBlockObject
     auto cfgBlockOfInterest = std::make_unique<CFGBlock>(clangBlockOfInterest);

--- a/include/rosdiscover-clang/BackwardSymbolizer/FunctionSymbolizer.h
+++ b/include/rosdiscover-clang/BackwardSymbolizer/FunctionSymbolizer.h
@@ -808,7 +808,7 @@ private:
       if (postdominatorAnalysis.dominates(depsBlock, blockOfInterest) && !dominatorAnalysis.dominates(depsBlock, blockOfInterest))
         continue; //ignore CFG blocks that come after the block of interest.
       auto depsCfgBlock = new CFGBlock(depsBlock);
-      blockMap.emplace(depsBlock->getBlockID(), cfgBlockOfInterest);
+      blockMap.emplace(depsBlock->getBlockID(), depsCfgBlock);
       controlDependencyGraphNodes.push_back(depsCfgBlock);
     }
     llvm::outs() << "#### buildGraph ####\n";

--- a/include/rosdiscover-clang/BackwardSymbolizer/FunctionSymbolizer.h
+++ b/include/rosdiscover-clang/BackwardSymbolizer/FunctionSymbolizer.h
@@ -858,41 +858,6 @@ private:
         
         llvm::outs() << "terminator condition found: " << conditionStr << "\n";
 
-        bool trueBranchDominates = false;
-        bool falseBranchDominates = false;
-
-        int i = 0;
-        for (const clang::CFGBlock *sBlock: block->succs()) {
-          if (i == 0) { //true branch, as defined by clang's order of successors
-
-            if (dominatorAnalysis.dominates(sBlock, prevBlock)) {
-              llvm::outs() << "true branch dominates stmt\n";
-              trueBranchDominates = true;
-            }
-          } else if (i == 1) { //false branch
-            if (dominatorAnalysis.dominates(sBlock, prevBlock)) {
-              llvm::outs() << "false branch dominates stmt\n";
-              falseBranchDominates = true;
-            }
-          } else {
-            //TODO: Handle switch-case here
-            llvm::outs() << "Too many branches. Swich not yet supported\n";
-            abort();
-          }
-          llvm::outs() << i++;
-          sBlock->dump();
-        }
-        if (trueBranchDominates && falseBranchDominates){
-          llvm::outs() << "ERROR: falseBranchDominates: " << falseBranchDominates << " trueBranchDominates: " << trueBranchDominates << "\n";
-          llvm::outs() << "prevBlock: ";
-          prevBlock->dump();
-          llvm::outs() << "\nblock: ";
-          block->dump();
-          llvm::outs() << "\nCFG: ";
-          sourceCFG->dump(clang::LangOptions(), false);
-          abort();
-        }
-
         std::vector<std::unique_ptr<SymbolicCall>> functionCalls;
         std::vector<std::unique_ptr<SymbolicVariableReference>> variableReferences;
         for (auto delcRef : getTransitiveChildenByType(condition, true, false)) {
@@ -913,7 +878,6 @@ private:
           std::make_unique<SymbolicControlDependency>(
             std::move(functionCalls), 
             std::move(variableReferences),
-            falseBranchDominates, //if the false branch dominates the statement, we need to negate the condition
             condition->getSourceRange().printToString(astContext.getSourceManager()),
             conditionStr
           )

--- a/include/rosdiscover-clang/BackwardSymbolizer/FunctionSymbolizer.h
+++ b/include/rosdiscover-clang/BackwardSymbolizer/FunctionSymbolizer.h
@@ -753,6 +753,8 @@ private:
             llvm::outs() << "ERROR: falseBranchDominates: " << falseBranchDominates << " trueBranchDominates: " << trueBranchDominates << "\n";
             llvm::outs() << "depBlock->getClangBlock(): ";
             depBlock->getClangBlock()->dump();
+            llvm::outs() << "\npredecessor->getClangBlock(): ";
+            predecessor->getClangBlock()->dump();
             abort();
           }
           

--- a/include/rosdiscover-clang/BackwardSymbolizer/FunctionSymbolizer.h
+++ b/include/rosdiscover-clang/BackwardSymbolizer/FunctionSymbolizer.h
@@ -756,7 +756,7 @@ private:
             abort();
           }
           
-          llvm::outs() << "creating edge\n";
+          // Creating edge
           CFGEdge::EdgeType type;
           if (i == 1) {
             type = CFGEdge::EdgeType::Normal;

--- a/include/rosdiscover-clang/BackwardSymbolizer/FunctionSymbolizer.h
+++ b/include/rosdiscover-clang/BackwardSymbolizer/FunctionSymbolizer.h
@@ -787,6 +787,8 @@ private:
     blockMap.emplace(block->getBlockID(), cfgBlock);
     std::vector<CFGBlock*> controlDependencyGraphNodes = {cfgBlock};
     for (auto depsBlock: deps) {
+      if (postdominatorAnalysis.dominates(depsBlock, block) && !dominatorAnalysis.dominates(depsBlock, block))
+        continue;
       auto depsCfgBlock = new CFGBlock(depsBlock);
       blockMap.emplace(depsBlock->getBlockID(), depsCfgBlock);
       controlDependencyGraphNodes.push_back(depsCfgBlock);

--- a/include/rosdiscover-clang/BackwardSymbolizer/FunctionSymbolizer.h
+++ b/include/rosdiscover-clang/BackwardSymbolizer/FunctionSymbolizer.h
@@ -783,14 +783,14 @@ private:
   CFGBlock* buildGraph(const clang::CFGBlock* blockOfInterest, const llvm::SmallVector<clang::CFGBlock *, 4> &deps, clang::CFGDominatorTreeImpl<true> &postdominatorAnalysis, clang::CFGDominatorTreeImpl<false> &dominatorAnalysis) {
     std::vector<const clang::CFGBlock*> analyzed;
     std::unordered_map<long, CFGBlock*> blockMap; //maps BlockID to CFGBlockObject
-    auto cfgBlock = new CFGBlock(blockOfInterest);
-    blockMap.emplace(blockOfInterest->getBlockID(), cfgBlock);
-    std::vector<CFGBlock*> controlDependencyGraphNodes = {cfgBlock};
+    auto cfgBlockOfInterest = new CFGBlock(blockOfInterest);
+    blockMap.emplace(blockOfInterest->getBlockID(), cfgBlockOfInterest);
+    std::vector<CFGBlock*> controlDependencyGraphNodes = {cfgBlockOfInterest};
     for (auto depsBlock: deps) {
       if (postdominatorAnalysis.dominates(depsBlock, blockOfInterest) && !dominatorAnalysis.dominates(depsBlock, blockOfInterest))
         continue; //ignore CFG blocks that come after the block of interest.
       auto depsCfgBlock = new CFGBlock(depsBlock);
-      blockMap.emplace(depsBlock->getBlockID(), depsCfgBlock);
+      blockMap.emplace(depsBlock->getBlockID(), cfgBlockOfInterest);
       controlDependencyGraphNodes.push_back(depsCfgBlock);
     }
     llvm::outs() << "#### buildGraph ####\n";

--- a/include/rosdiscover-clang/BackwardSymbolizer/FunctionSymbolizer.h
+++ b/include/rosdiscover-clang/BackwardSymbolizer/FunctionSymbolizer.h
@@ -730,7 +730,7 @@ private:
           llvm::outs() << "\n";
           for (const clang::CFGBlock *sBlock: predecessor->getClangBlock()->succs()) {
             if (i == 0) { //true branch, as defined by clang's order of successors
-            //TODO: build the whole graph, not just a small part, check whether paths lead to any control dependency block, not just the previous
+            //TODO: Ensure that no blocks are skipped
               if (dominatorAnalysis->isReachable(sBlock, block) || depBlock->getClangBlock()->getBlockID() == sBlock->getBlockID()) {
                 llvm::outs() << "true branch dominates stmt\n";
                 trueBranchDominates = true;

--- a/include/rosdiscover-clang/BackwardSymbolizer/FunctionSymbolizer.h
+++ b/include/rosdiscover-clang/BackwardSymbolizer/FunctionSymbolizer.h
@@ -691,7 +691,16 @@ private:
   }
 
   // Recursively builds a graph of control dependencies starting from the last block.
-  std::vector<CFGBlock*> buildGraph(bool first, const clang::CFGBlock* block, const llvm::SmallVector<clang::CFGBlock *, 4> &deps, clang::CFGDominatorTreeImpl<true> &postdominatorAnalysis, clang::CFGDominatorTreeImpl<false> &dominatorAnalysis, std::vector<const clang::CFGBlock*> &analyzed, std::vector<CFGBlock*> &controlDependencyGraphNodes, std::unordered_map<long, CFGBlock*> &blockMap) {
+  std::vector<CFGBlock*> buildGraph(
+    bool first,
+    const clang::CFGBlock* block,
+    const llvm::SmallVector<clang::CFGBlock *, 4> &deps,
+    clang::CFGDominatorTreeImpl<true> &postdominatorAnalysis,
+    clang::CFGDominatorTreeImpl<false> &dominatorAnalysis,
+    std::vector<const clang::CFGBlock*> &analyzed,
+    std::vector<CFGBlock*> &controlDependencyGraphNodes,
+    std::unordered_map<long, CFGBlock*> &blockMap
+  ) {
     std::vector<CFGBlock*> predecessors;
     if (block == nullptr || block->pred_empty() || llvm::is_contained(analyzed, block)) {
       return predecessors;
@@ -704,7 +713,16 @@ private:
 
     // Recursively build the graph for the block's predecessors
     for (const clang::CFGBlock::AdjacentBlock predecessorBlock: block->preds()) {
-      auto indirectPredecessors = buildGraph(false, predecessorBlock.getReachableBlock(), deps, postdominatorAnalysis, dominatorAnalysis, analyzed, controlDependencyGraphNodes, blockMap);
+      auto indirectPredecessors = buildGraph(
+        false,
+        predecessorBlock.getReachableBlock(),
+        deps,
+        postdominatorAnalysis,
+        dominatorAnalysis,
+        analyzed,
+        controlDependencyGraphNodes,
+        blockMap
+      );
       predecessors.insert(predecessors.end(), indirectPredecessors.begin(), indirectPredecessors.end()); //merge results
     }
 

--- a/include/rosdiscover-clang/BackwardSymbolizer/FunctionSymbolizer.h
+++ b/include/rosdiscover-clang/BackwardSymbolizer/FunctionSymbolizer.h
@@ -729,10 +729,13 @@ private:
           predecessor->getClangBlock()->dump();
           llvm::outs() << "\n";
           for (const clang::CFGBlock *sBlock: predecessor->getClangBlock()->succs()) {
-            if ((postdominatorAnalysis.dominates(depBlock->getClangBlock(), sBlock) && !dominatorAnalysis.dominates(depBlock->getClangBlock(), sBlock)) || depBlock->getClangBlock()->getBlockID() == sBlock->getBlockID()) {
-              if (i == 0) { //true branch, as defined by clang's order of successors
-              //TODO: Ensure that no blocks are skipped
-                //the only post-dominating control dependency is the directly following control dependency
+            // The only post-dominating control dependency is the directly following control dependency,
+            // The exception to this is the head of a loop, which is the only control dependency which then also pre-dominiates the 
+            // inner statement. Hence those edges need to be ignored to avoid circles in the control dependcy graph. 
+            if ((postdominatorAnalysis.dominates(depBlock->getClangBlock(), sBlock) 
+              && !dominatorAnalysis.dominates(depBlock->getClangBlock(), sBlock)) 
+              || depBlock->getClangBlock()->getBlockID() == sBlock->getBlockID()) {
+              if (i == 0) { //true branch, as defined by clang's order of successors                
                   llvm::outs() << "true branch dominates stmt\n";
                   trueBranchDominates = true;
               } else if (i == 1) { //false branch

--- a/include/rosdiscover-clang/BackwardSymbolizer/FunctionSymbolizer.h
+++ b/include/rosdiscover-clang/BackwardSymbolizer/FunctionSymbolizer.h
@@ -731,6 +731,7 @@ private:
         llvm::outs() << "\n";
         for (const clang::CFGBlock *sBlock: predecessor->getClangBlock()->succs()) {
           if (i == 0) { //true branch, as defined by clang's order of successors
+          //TODO: build the whole graph, not just a small part, check whether paths lead to any control dependency block, not just the previous
             if (dominatorAnalysis->isReachable(sBlock, block) || block->getBlockID() == sBlock->getBlockID()) {
               llvm::outs() << "true branch dominates stmt\n";
               trueBranchDominates = true;
@@ -809,8 +810,9 @@ private:
       block->dump();
     }
     auto graph = buildGraph(stmt_block, deps, analysis.get());
-    
     graph->getClangBlock()->dump();
+    auto condStr = graph->getFullConditionStr(astContext);
+    llvm::outs() << "\nFullControlCondition: " << condStr << "\n";
 
     for (clang::CFGBlock *block: deps) {
 
@@ -852,6 +854,7 @@ private:
         int i = 0;
         for (const clang::CFGBlock *sBlock: block->succs()) {
           if (i == 0) { //true branch, as defined by clang's order of successors
+
             if (dominatorAnalysis.dominates(sBlock, prevBlock)) {
               llvm::outs() << "true branch dominates stmt\n";
               trueBranchDominates = true;

--- a/include/rosdiscover-clang/Cfg/CFGBlock.h
+++ b/include/rosdiscover-clang/Cfg/CFGBlock.h
@@ -11,12 +11,12 @@ class CFGEdge;
 class CFGBlock {
 public:
   CFGBlock(
-    const clang::Stmt* stmt
-  ) : stmt(stmt), predecessors(), successors() {}
+    const clang::CFGBlock* clangBlock
+  ) : clangBlock(clangBlock), predecessors(), successors() {}
   ~CFGBlock(){}
 
-  const clang::Stmt* getStmt() {
-    return stmt;
+  const clang::CFGBlock* getClangBlock() {
+    return clangBlock;
   }
 
   std::vector<CFGEdge*> getSuccessors() {
@@ -42,7 +42,7 @@ public:
   }
    
 private: 
-  const clang::Stmt* stmt;
+  const clang::CFGBlock* clangBlock;
   std::vector<CFGEdge*> predecessors;
   std::vector<CFGEdge*> successors;
 

--- a/include/rosdiscover-clang/Cfg/CFGBlock.h
+++ b/include/rosdiscover-clang/Cfg/CFGBlock.h
@@ -59,9 +59,11 @@ public:
         abort();
       }
     }
+    
     if (!includeSelf) {
       return result;
     }
+
     auto myStr = negate ? "!(" + getConditionStr(astContext) + ")" : getConditionStr(astContext);
     if (result == "") 
       return myStr;

--- a/include/rosdiscover-clang/Cfg/CFGBlock.h
+++ b/include/rosdiscover-clang/Cfg/CFGBlock.h
@@ -39,7 +39,7 @@ public:
   std::string getConditionStr(clang::ASTContext &astContext) const {
     const auto *condition = clangBlock->getTerminatorCondition();
     if (condition == nullptr) {
-      return rosdiscover::prettyPrint(condition, astContext);
+      return "[" + std::to_string(clangBlock->getBlockID()) + "]";
     }
     return rosdiscover::prettyPrint(condition, astContext);
   }

--- a/include/rosdiscover-clang/Cfg/CFGBlock.h
+++ b/include/rosdiscover-clang/Cfg/CFGBlock.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <string>
+
+#include <clang/AST/Stmt.h>
+
+#include "CFGEdge.h"
+
+namespace rosdiscover {
+class CFGEdge;
+class CFGBlock {
+public:
+  CFGBlock(
+    const clang::Stmt* stmt
+  ) : stmt(stmt), predecessors(), successors() {}
+  ~CFGBlock(){}
+
+  const clang::Stmt* getStmt() {
+    return stmt;
+  }
+
+  std::vector<CFGEdge*> getSuccessors() {
+    return successors;
+  }
+
+  std::vector<CFGEdge*> getPredecessors() {
+    return predecessors;
+  }
+
+  void addSuccessor(CFGEdge* edge) {
+    successors.push_back(edge);
+  }
+
+  void addPredecessor(CFGEdge* edge) {
+    predecessors.push_back(edge);
+  }
+
+  void createEdge(CFGBlock* successor, CFGEdge::EdgeType type) {
+    auto edge = new CFGEdge(this, successor, type);
+    this->addSuccessor(edge);
+    successor->addPredecessor(edge);
+  }
+   
+private: 
+  const clang::Stmt* stmt;
+  std::vector<CFGEdge*> predecessors;
+  std::vector<CFGEdge*> successors;
+
+};
+} // rosdiscover

--- a/include/rosdiscover-clang/Cfg/CFGBlock.h
+++ b/include/rosdiscover-clang/Cfg/CFGBlock.h
@@ -39,8 +39,7 @@ public:
   std::string getConditionStr(clang::ASTContext &astContext) const {
     const auto *condition = clangBlock->getTerminatorCondition();
     if (condition == nullptr) {
-      llvm::outs() << "no terminator condition\n";
-      return "unknown";
+      return rosdiscover::prettyPrint(condition, astContext);
     }
     return rosdiscover::prettyPrint(condition, astContext);
   }
@@ -75,10 +74,20 @@ public:
       return "(" + result + ") && " + myStr;
   }
 
-  void createEdge(CFGBlock* successor, CFGEdge::EdgeType type) {
+  inline bool operator==(const CFGBlock& rhs) const { 
+    return clangBlock->getBlockID() == rhs.clangBlock->getBlockID();
+  }
+
+  bool createEdge(CFGBlock* successor, CFGEdge::EdgeType type) {
     auto edge = new CFGEdge(this, successor, type);
+    for (auto pEdge : predecessors) {
+      if (pEdge == edge) {
+        return false;
+      }
+    }
     this->addSuccessor(edge);
     successor->addPredecessor(edge);
+    return true;
   }
    
 private: 

--- a/include/rosdiscover-clang/Cfg/CFGBlock.h
+++ b/include/rosdiscover-clang/Cfg/CFGBlock.h
@@ -36,10 +36,10 @@ public:
     return rosdiscover::prettyPrint(condition, astContext);
   }
 
-  std::string getFullConditionStr(clang::ASTContext &astContext, bool negate = false) const {
+  std::string getFullConditionStr(bool includeSelf, clang::ASTContext &astContext, bool negate) const {
     std::string result = "";
     for (auto edge: predecessors) {
-      auto pStr = edge->getPredecessor()->getFullConditionStr(astContext, edge->getType() == CFGEdge::EdgeType::False);
+      auto pStr = edge->getPredecessor()->getFullConditionStr(true, astContext, edge->getType() == CFGEdge::EdgeType::False);
       if (pStr == "")
         continue;
 
@@ -59,11 +59,18 @@ public:
         abort();
       }
     }
+    if (!includeSelf) {
+      return result;
+    }
     auto myStr = negate ? "!(" + getConditionStr(astContext) + ")" : getConditionStr(astContext);
     if (result == "") 
       return myStr;
     else
       return "(" + result + ") && " + myStr;
+  }
+
+  std::string getFullConditionStr(clang::ASTContext &astContext) const {
+    return getFullConditionStr(false, astContext, false);
   }
 
   bool createEdge(CFGBlock* successor, CFGEdge::EdgeType type) {

--- a/include/rosdiscover-clang/Cfg/CFGBlock.h
+++ b/include/rosdiscover-clang/Cfg/CFGBlock.h
@@ -15,7 +15,7 @@ public:
   ) : clangBlock(clangBlock), predecessors(), successors() {}
   ~CFGBlock(){}
 
-  const clang::CFGBlock* getClangBlock() {
+  const clang::CFGBlock* getClangBlock() const {
     return clangBlock;
   }
 

--- a/include/rosdiscover-clang/Cfg/CFGEdge.h
+++ b/include/rosdiscover-clang/Cfg/CFGEdge.h
@@ -18,6 +18,27 @@ public:
       Unknown,
   };
 
+  static std::string getEdgeTypeName(const EdgeType type) {
+    switch (type) {
+      case True:
+        return "True";
+      case False:
+        return "False";
+      case Normal:
+        return "Normal";
+      case Unknown:
+        return "Unknown";
+    }
+  }
+
+  inline bool operator==(const CFGEdge& rhs) const { 
+    return 
+      predecessor == rhs.predecessor &&
+      successor == rhs.successor &&
+      edgeType == rhs.edgeType
+    ;
+  }
+
   CFGEdge(
     CFGBlock* predecessor,
     CFGBlock* successor,

--- a/include/rosdiscover-clang/Cfg/CFGEdge.h
+++ b/include/rosdiscover-clang/Cfg/CFGEdge.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <string>
+
+#include <clang/AST/Stmt.h>
+
+#include "CFGBlock.h"
+
+namespace rosdiscover {
+class CFGBlock;
+class CFGEdge {
+public:
+
+  enum EdgeType {
+      True,
+      False,
+      Normal,
+  };
+
+  CFGEdge(
+    CFGBlock* predecessor,
+    CFGBlock* successor,
+    EdgeType edgeType
+  ) : predecessor(predecessor), successor(successor), edgeType(edgeType) {}
+
+  CFGEdge(const CFGEdge &edge) : predecessor(edge.predecessor), successor(edge.successor), edgeType(edge.edgeType) {}
+
+  ~CFGEdge(){}
+
+  EdgeType getType() {
+    return edgeType;
+  }
+
+  CFGBlock* getSuccessor() {
+    return successor;
+  }
+
+  CFGBlock* getPredecessor() {
+    return predecessor;
+  }
+
+private:
+  CFGBlock* predecessor;
+  CFGBlock* successor;
+  EdgeType edgeType;
+};
+
+} // rosdiscover

--- a/include/rosdiscover-clang/Cfg/CFGEdge.h
+++ b/include/rosdiscover-clang/Cfg/CFGEdge.h
@@ -15,6 +15,7 @@ public:
       True,
       False,
       Normal,
+      Unknown,
   };
 
   CFGEdge(


### PR DESCRIPTION
This PR reconstructs the Control Dependency Graph for API calls and then combines individual conditions using logical operators.

Right now the conditions are only printed to the logs and not the JSON output. This is going to happen once symbolic expressions are created.