### PR TITLE
Fix dependent types

### DIFF
--- a/include/rosdiscover-clang/ApiCall/Calls/Util.h
+++ b/include/rosdiscover-clang/ApiCall/Calls/Util.h
@@ -90,8 +90,21 @@ clang::APValue const * evaluateNumber(
   const clang::ASTContext &Ctx,
   bool debugPrint=true
   ) {
+
+  if (expr->isValueDependent()) {
+    if (debugPrint) {
+      llvm::outs() << "DEBUG [" << debugTag << "]: Is value-dependent and cannot be evaluated: "; 
+      expr->dump();
+      llvm::outs() << "\n";
+    }
+
+    return nullptr;
+  }
+
+
   //Try evaluating the frequency as integer.
   clang::Expr::EvalResult resultInt;
+
   if (expr->EvaluateAsInt(resultInt, Ctx)) {
     llvm::outs() << "DEBUG [" << debugTag << "]: evaluated INT: (" << resultInt.Val.getInt().getSExtValue() << ")\n";
     return new clang::APValue(resultInt.Val);

--- a/include/rosdiscover-clang/BackwardSymbolizer/ExprSymbolizer.h
+++ b/include/rosdiscover-clang/BackwardSymbolizer/ExprSymbolizer.h
@@ -146,7 +146,7 @@ public:
     } else if (auto *enumDecl = clang::dyn_cast<clang::EnumConstantDecl>(decl)) {
       clang::Expr::EvalResult resultInt;
       long enumValue = -1;
-      if (declRefExpr->EvaluateAsInt(resultInt, astContext)) {
+      if (!declRefExpr->isValueDependent() && declRefExpr->EvaluateAsInt(resultInt, astContext)) {
         enumValue = resultInt.Val.getInt().getSExtValue();
       }
       return std::make_unique<SymbolicEnumReference>(enumDecl->getType().getAsString(), enumDecl->getNameAsString(), enumDecl->getQualifiedNameAsString(), enumValue);

--- a/include/rosdiscover-clang/BackwardSymbolizer/IntSymbolizer.h
+++ b/include/rosdiscover-clang/BackwardSymbolizer/IntSymbolizer.h
@@ -37,7 +37,7 @@ public:
 
     //Try evaluating the frequency as integer.
     clang::Expr::EvalResult resultInt;
-    if (expr->EvaluateAsInt(resultInt, astContext)) {
+    if (!expr->isValueDependent() && expr->EvaluateAsInt(resultInt, astContext)) {
       llvm::outs() << "DEBUG [IntSymbolizer]: evaluated INT: (" << resultInt.Val.getInt().getSExtValue() << ")\n";
       return valueBuilder.integerLiteral(resultInt.Val.getInt().getSExtValue());
     }


### PR DESCRIPTION
Previously we got this error:
```
DEBUG: determining symbolic type for Clang type [<dependent type>]
rosdiscover-cxx-extract: /tmp/llvm/clang/lib/AST/ExprConstant.cpp:14176: bool clang::Expr::EvaluateAsInt(clang::Expr::EvalResult&, const clang::ASTContext&, clang::Expr::SideEffectsKind, bool) const: Assertion `!isValueDependent() && "Expression evaluator can't be called on a dependent expression."' failed.
2023-06-28 18:02:35.103 | ERROR    | __main__:recover_node_from_sources:374 - failed to statically recover model for node [ladybug_camera] in package [pointgrey]
```
Checking this conditions fixes this bug